### PR TITLE
Add BLAS/LAPACK feature for R, conditionally use f32 implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarabel"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Paul Goulart <paul.goulart@eng.ox.ac.uk>"]
 edition = "2021"
 rust-version = "1.60"
@@ -37,6 +37,7 @@ sdp-accelerate = ["sdp", "blas-src/accelerate", "lapack-src/accelerate"]
 sdp-netlib     = ["sdp", "blas-src/netlib", "lapack-src/netlib"]
 sdp-openblas   = ["sdp", "blas-src/openblas", "lapack-src/openblas"]
 sdp-mkl        = ["sdp", "blas-src/intel-mkl", "lapack-src/intel-mkl"]
+sdp-r          = ["sdp", "blas-src/r", "lapack-src/r"]
 
 # build as the julia interface 
 julia = ["sdp", "dep:libc", "dep:num-derive", "dep:serde", "dep:serde_json"] 
@@ -61,11 +62,11 @@ version = "0.19.0"
 optional = true
 
 [dependencies.blas-src]
-version = "0.8"
+version = "0.9"
 optional = true 
 
 [dependencies.lapack-src]
-version = "0.8"
+version = "0.9"
 optional = true 
 
 

--- a/src/algebra/dense/blas.rs
+++ b/src/algebra/dense/blas.rs
@@ -30,13 +30,24 @@ pub trait BlasFloatT:
     + XsyrkScalar
     + Xsyr2kScalar
 {}
-impl BlasFloatT for f32 {}
+
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+	// R blas/lapack only provides double precision routines
+	impl BlasFloatT for f32 {}
+  }
+}
 impl BlasFloatT for f64 {}
 
 mod private {
- pub trait BlasFloatSealed {}
- impl BlasFloatSealed for f32 {}
- impl BlasFloatSealed for f64 {}
+  pub trait BlasFloatSealed {}
+  cfg_if::cfg_if! {
+	if #[cfg(not(feature="sdp-r"))] {
+	    // R blas/lapack only provides double precision routines
+	    impl BlasFloatSealed for f32 {}     
+	}
+  }
+  impl BlasFloatSealed for f64 {}
 }
 
 
@@ -71,7 +82,12 @@ macro_rules! impl_blas_xsyevr {
     };
 }
 
-impl_blas_xsyevr!(f32, ssyevr);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_xsyevr!(f32, ssyevr);      
+  }
+}
 impl_blas_xsyevr!(f64, dsyevr);
 
 // --------------------------------------
@@ -100,7 +116,12 @@ macro_rules! impl_blas_xpotrf{
     };
 }
 
-impl_blas_xpotrf!(f32, spotrf);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_xpotrf!(f32, spotrf);      
+  }
+}
 impl_blas_xpotrf!(f64, dpotrf);
 
 
@@ -134,7 +155,12 @@ macro_rules! impl_blas_xgesdd{
     };
 }
 
-impl_blas_xgesdd!(f32, sgesdd);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_xgesdd!(f32, sgesdd);
+  }
+}
 impl_blas_xgesdd!(f64, dgesdd);
 
 
@@ -168,7 +194,12 @@ macro_rules! impl_blas_xgesvd{
     };
 }
 
-impl_blas_xgesvd!(f32, sgesvd);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_xgesvd!(f32, sgesvd);
+  }
+}
 impl_blas_xgesvd!(f64, dgesvd);
 
 
@@ -201,7 +232,12 @@ macro_rules! impl_blas_gemm {
     };
 }
 
-impl_blas_gemm!(f32, sgemm);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_gemm!(f32, sgemm);
+  }
+}
 impl_blas_gemm!(f64, dgemm);
 
 // --------------------------------------
@@ -233,7 +269,12 @@ macro_rules! impl_blas_gemv {
     };
 }
 
-impl_blas_gemv!(f32, sgemv);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_gemv!(f32, sgemv);
+  }
+}
 impl_blas_gemv!(f64, dgemv);
 
 
@@ -266,7 +307,12 @@ macro_rules! impl_blas_gsymv {
     };
 }
 
-impl_blas_gsymv!(f32, ssymv);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_gsymv!(f32, ssymv);
+  }
+}
 impl_blas_gsymv!(f64, dsymv);
 
 
@@ -299,7 +345,12 @@ macro_rules! impl_blas_gsyrk {
     };
 }
 
-impl_blas_gsyrk!(f32, ssyrk);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_gsyrk!(f32, ssyrk);
+  }
+}
 impl_blas_gsyrk!(f64, dsyrk);
 
 // --------------------------------------
@@ -332,5 +383,10 @@ macro_rules! impl_blas_gsyr2k {
     };
 }
 
-impl_blas_gsyr2k!(f32, ssyr2k);
+cfg_if::cfg_if! {
+  if #[cfg(not(feature="sdp-r"))] {
+      // R blas/lapack only provides double precision routines
+      impl_blas_gsyr2k!(f32, ssyr2k);
+  }
+}
 impl_blas_gsyr2k!(f64, dsyr2k);


### PR DESCRIPTION
The cargo for blas-src and lapack-src now provides a feature "r" for using the blas and lapack that come with R. However, the R blas/lapack only provides double precision routines. So this also includes patches to conditionally compile only double precision routines when feature "sdp-r" is used.  This addresses [issue](https://github.com/oxfordcontrol/clarabel-r/issues/4) raised by @goulart-paul. 

PS. I have tested this with rust version 1.69.0. 