### PR TITLE
Add methods for problem data updates

### DIFF
--- a/src/algebra/csc/core.rs
+++ b/src/algebra/csc/core.rs
@@ -210,6 +210,22 @@ where
 
         Ok(())
     }
+    /// True if matrices if the same size and sparsity pattern
+    pub fn is_equal_sparsity(&self, other: &Self) -> bool {
+        self.size() == other.size() && self.colptr == other.colptr && self.rowval == other.rowval
+    }
+
+    /// Same as is_equal_sparsity, but returns an error indicating the reason
+    /// for failure if the matrices do not have equivalent sparsity patterns.
+    pub fn check_equal_sparsity(&self, other: &Self) -> Result<(), SparseFormatError> {
+        if self.size() != other.size() {
+            Err(SparseFormatError::IncompatibleDimension)
+        } else if self.colptr != other.colptr || self.rowval != other.rowval {
+            Err(SparseFormatError::SparsityMismatch)
+        } else {
+            Ok(())
+        }
+    }
 
     /// Select a subset of the rows of a sparse matrix
     ///

--- a/src/algebra/csc/core.rs
+++ b/src/algebra/csc/core.rs
@@ -363,12 +363,8 @@ where
     /// Panics if the given index is out of bounds.
     pub fn index_to_coord(&self, idx: usize) -> (usize, usize) {
         assert!(idx < self.nnz());
-        println!("\n\n index to coord");
-        println!("idx = {}", idx);
-        println!("colptr = {:?}", self.colptr);
         let row = self.rowval[idx];
         let col = self.colptr.partition_point(|&c| idx + 1 > c) - 1;
-        println!("col = {}", col);
         (row, col)
     }
 }

--- a/src/algebra/csc/core.rs
+++ b/src/algebra/csc/core.rs
@@ -356,6 +356,21 @@ where
             Err(_) => None,
         }
     }
+
+    /// Returns the (row,col) coordinates of the given linear index.
+    ///
+    /// # Panics
+    /// Panics if the given index is out of bounds.
+    pub fn index_to_coord(&self, idx: usize) -> (usize, usize) {
+        assert!(idx < self.nnz());
+        println!("\n\n index to coord");
+        println!("idx = {}", idx);
+        println!("colptr = {:?}", self.colptr);
+        let row = self.rowval[idx];
+        let col = self.colptr.partition_point(|&c| idx + 1 > c) - 1;
+        println!("col = {}", col);
+        (row, col)
+    }
 }
 
 impl<T> ShapedMatrix for CscMatrix<T> {
@@ -477,6 +492,33 @@ fn test_csc_get_entry() {
     assert_eq!(A.get_entry((2, 3)), None);
     assert_eq!(A.get_entry((4, 3)), None);
     assert_eq!(A.get_entry((3, 4)), None);
+}
+
+#[test]
+fn test_csc_index_to_coord() {
+    let A = CscMatrix::from(&[
+        [0.0, 4.0, 0.0, 0.0, 12.0],
+        [1.0, 5.0, 0.0, 0.0, 0.0],
+        [0.0, 6.0, 0.0, 0.0, 13.0],
+        [2.0, 7.0, 10.0, 0.0, 0.0],
+        [0.0, 8.0, 11.0, 0.0, 14.0],
+        [3.0, 9.0, 0.0, 0.0, 0.0],
+    ]);
+
+    assert_eq!(A.index_to_coord(0), (1, 0));
+    assert_eq!(A.index_to_coord(1), (3, 0));
+    assert_eq!(A.index_to_coord(2), (5, 0));
+    assert_eq!(A.index_to_coord(3), (0, 1));
+    assert_eq!(A.index_to_coord(4), (1, 1));
+    assert_eq!(A.index_to_coord(5), (2, 1));
+    assert_eq!(A.index_to_coord(6), (3, 1));
+    assert_eq!(A.index_to_coord(7), (4, 1));
+    assert_eq!(A.index_to_coord(8), (5, 1));
+    assert_eq!(A.index_to_coord(9), (3, 2));
+    assert_eq!(A.index_to_coord(10), (4, 2));
+    assert_eq!(A.index_to_coord(11), (0, 4));
+    assert_eq!(A.index_to_coord(12), (2, 4));
+    assert_eq!(A.index_to_coord(13), (4, 4));
 }
 
 #[test]

--- a/src/algebra/csc/utils.rs
+++ b/src/algebra/csc/utils.rs
@@ -119,6 +119,7 @@ where
 
     // populate values from M using the self.colptr as indicator of
     // next fill location in each row.
+    #[allow(clippy::needless_range_loop)]
     pub(crate) fn fill_block(
         &mut self,
         M: &CscMatrix<T>,
@@ -128,29 +129,28 @@ where
         shape: MatrixShape,
     ) {
         for i in 0..M.n {
-            let z = zip(&M.rowval, &M.nzval);
             let start = M.colptr[i];
             let stop = M.colptr[i + 1];
 
-            for (j, (&Mrow, &Mval)) in z.take(stop).skip(start).enumerate() {
+            for j in start..stop {
                 let (col, row);
 
                 match shape {
                     MatrixShape::T => {
-                        col = Mrow + initcol;
+                        col = M.rowval[j] + initcol;
                         row = i + initrow;
                     }
                     MatrixShape::N => {
                         col = i + initcol;
-                        row = Mrow + initrow;
+                        row = M.rowval[j] + initrow;
                     }
                 };
 
                 let dest = self.colptr[col];
                 self.rowval[dest] = row;
-                self.nzval[dest] = Mval;
-                self.colptr[col] += 1;
+                self.nzval[dest] = M.nzval[j];
                 MtoKKT[j] = dest;
+                self.colptr[col] += 1;
             }
         }
     }

--- a/src/algebra/error_types.rs
+++ b/src/algebra/error_types.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// Error type returned by the [`check_format`](crate::algebra::CscMatrix::check_format) utility.
+/// Error type returned by sparse matrix user input checkers, e.g. [`check_format`](crate::algebra::CscMatrix::check_format) utility.
 #[derive(Error, Debug)]
 pub enum SparseFormatError {
     #[error("Matrix dimension fields and/or array lengths are incompatible")]
@@ -11,6 +11,8 @@ pub enum SparseFormatError {
     BadRowval,
     #[error("Bad column pointer values")]
     BadColptr,
+    #[error("sparsity pattern mismatch")]
+    SparsityMismatch,
 }
 
 /// Error type returned by BLAS-like dense factorization routines.  Errors

--- a/src/algebra/math_traits.rs
+++ b/src/algebra/math_traits.rs
@@ -105,15 +105,22 @@ pub trait VectorMath {
     /// 2-norm
     fn norm(&self) -> Self::T;
 
-    /// 2-norm of an elementwise scaling of `self` by `v`
-    fn norm_scaled(&self, v: &Self) -> Self::T;
-
     /// Infinity norm
     fn norm_inf(&self) -> Self::T;
 
     /// One norm
     fn norm_one(&self) -> Self::T;
 
+    /// 2-norm of an elementwise scaling of `self` by `v`
+    fn norm_scaled(&self, v: &Self) -> Self::T;
+
+    /// Inf-norm of an elementwise scaling of `self` by `v`
+    fn norm_inf_scaled(&self, v: &Self) -> Self::T;
+
+    /// Inf-norm of an elementwise scaling of `self` by `v`
+    fn norm_one_scaled(&self, v: &Self) -> Self::T;
+
+    // Inf-norm of vector difference
     fn norm_inf_diff(&self, b: &Self) -> Self::T;
 
     /// Minimum value in vector

--- a/src/algebra/vecmath.rs
+++ b/src/algebra/vecmath.rs
@@ -115,16 +115,6 @@ impl<T: FloatT> VectorMath for [T] {
         T::sqrt(self.sumsq())
     }
 
-    //scaled norm of elementwise produce self.*v
-    fn norm_scaled(&self, v: &[T]) -> T {
-        assert_eq!(self.len(), v.len());
-        let total = zip(self, v).fold(T::zero(), |acc, (&x, &y)| {
-            let prod = x * y;
-            acc + prod * prod
-        });
-        T::sqrt(total)
-    }
-
     // Returns infinity norm
     fn norm_inf(&self) -> T {
         let mut out = T::zero();
@@ -140,6 +130,27 @@ impl<T: FloatT> VectorMath for [T] {
     // Returns one norm
     fn norm_one(&self) -> T {
         self.iter().fold(T::zero(), |acc, v| acc + v.abs())
+    }
+
+    //two-norm of elementwise product self.*v
+    fn norm_scaled(&self, v: &[T]) -> T {
+        assert_eq!(self.len(), v.len());
+        let total = zip(self, v).fold(T::zero(), |acc, (&x, &y)| {
+            let prod = x * y;
+            acc + prod * prod
+        });
+        T::sqrt(total)
+    }
+
+    //inf-norm of elementwise product self.*v
+    fn norm_inf_scaled(&self, v: &Self) -> Self::T {
+        assert_eq!(self.len(), v.len());
+        zip(self, v).fold(T::zero(), |acc, (&x, &y)| T::max(acc, T::abs(x * y)))
+    }
+
+    //
+    fn norm_one_scaled(&self, v: &Self) -> Self::T {
+        zip(self, v).fold(T::zero(), |acc, (&x, &y)| acc + T::abs(x * y))
     }
 
     // max absolute difference (used for unit testing)

--- a/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
@@ -169,6 +169,14 @@ where
 
         is_success
     }
+
+    fn update_P(&mut self, P: &CscMatrix<T>) {
+        _update_values(&mut self.ldlsolver, &mut self.KKT, &self.map.P, &P.nzval);
+    }
+
+    fn update_A(&mut self, A: &CscMatrix<T>) {
+        _update_values(&mut self.ldlsolver, &mut self.KKT, &self.map.A, &A.nzval);
+    }
 }
 
 impl<T> DirectLDLKKTSolver<T>

--- a/src/solver/core/kktsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/mod.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use super::{cones::CompositeCone, CoreSettings};
 use crate::algebra::*;
 
@@ -12,4 +13,6 @@ pub trait KKTSolver<T: FloatT> {
         z: Option<&mut [T]>,
         settings: &CoreSettings<T>,
     ) -> bool;
+    fn update_P(&mut self, P: &CscMatrix<T>);
+    fn update_A(&mut self, A: &CscMatrix<T>);
 }

--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -218,7 +218,7 @@ where
             // convergence check and printing
             // --------------
             self.info.update(
-                &self.data,
+                &mut self.data,
                 &self.variables,
                 &self.residuals,&timers);
 

--- a/src/solver/core/traits.rs
+++ b/src/solver/core/traits.rs
@@ -182,7 +182,13 @@ where
     fn finalize(&mut self, residuals: &Self::R, settings: &Self::SE, timers: &mut Timers);
 
     /// Update solver progress information
-    fn update(&mut self, data: &Self::D, variables: &Self::V, residuals: &Self::R, timers: &Timers);
+    fn update(
+        &mut self,
+        data: &mut Self::D,
+        variables: &Self::V,
+        residuals: &Self::R,
+        timers: &Timers,
+    );
 
     /// Return `true` if termination conditions have been reached.
     fn check_termination(&mut self, residuals: &Self::R, settings: &Self::SE, iter: u32) -> bool;

--- a/src/solver/implementations/default/data_updating.rs
+++ b/src/solver/implementations/default/data_updating.rs
@@ -108,11 +108,10 @@ where
     ) -> Result<(), DataUpdateError> {
         self.check_presolve_disabled()?;
         let d = &self.data.equilibration.d;
-        let dinv = &self.data.equilibration.dinv;
         data.update_vector(&mut self.data.q, d)?;
 
-        //recover unscaled norm
-        self.data.normq = self.data.q.norm_inf_scaled(dinv);
+        // flush unscaled norm. Will be recalculated during solve
+        self.data.clear_normq();
 
         Ok(())
     }
@@ -124,11 +123,10 @@ where
     ) -> Result<(), DataUpdateError> {
         self.check_presolve_disabled()?;
         let e = &self.data.equilibration.e;
-        let einv = &self.data.equilibration.einv;
         data.update_vector(&mut self.data.b, e)?;
 
-        //recover unscaled norm
-        self.data.normb = self.data.b.norm_inf_scaled(einv);
+        // flush unscaled norm. Will be recalculated during solve
+        self.data.clear_normb();
 
         Ok(())
     }

--- a/src/solver/implementations/default/data_updating.rs
+++ b/src/solver/implementations/default/data_updating.rs
@@ -4,8 +4,7 @@ use crate::algebra::*;
 use core::iter::Zip;
 use core::slice::Iter;
 
-// Trait for updating P and A matrices
-
+// Trait for updating P and A matrices from various data types
 pub trait MatrixProblemDataUpdate<T: FloatT> {
     fn update_matrix(
         &self,
@@ -13,6 +12,128 @@ pub trait MatrixProblemDataUpdate<T: FloatT> {
         lscale: &[T],
         rscale: &[T],
     ) -> Result<(), SparseFormatError>;
+}
+
+// Trait for updating q and b vectors from various data types
+pub trait VectorProblemDataUpdate<T: FloatT> {
+    fn update_vector(&self, v: &mut [T], scale: &[T]) -> Result<(), SparseFormatError>;
+}
+
+impl<T> DefaultSolver<T>
+where
+    T: FloatT,
+{
+    /// Overwrites internal problem data structures in a solver object with new data, avoiding new memory allocations.   
+    /// See `update_P``, `update_q`, `update_A`, `update_b` for allowable inputs.
+
+    pub fn update_data<
+        DataP: MatrixProblemDataUpdate<T>,
+        Dataq: VectorProblemDataUpdate<T>,
+        DataA: MatrixProblemDataUpdate<T>,
+        Datab: VectorProblemDataUpdate<T>,
+    >(
+        &mut self,
+        P: &DataP,
+        q: &Dataq,
+        A: &DataA,
+        b: &Datab,
+    ) -> Result<(), SparseFormatError> {
+        self.update_P(P)?;
+        self.update_q(q)?;
+        self.update_A(A)?;
+        self.update_b(b)?;
+
+        Ok(())
+    }
+
+    /// Overwrites the `P` matrix data in an existing solver object.   The input `P` can be    
+    ///
+    /// - a nonempty Vector, in which case the nonzero values of the original `P` are overwritten, preserving the sparsity pattern, or
+    ///
+    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the upper triangular part of the original `P`.
+    ///
+    /// - an iterator zip(&index,&values), specifying a selective update of values.
+    ///
+    /// - an empty vector, in which case no action is taken.
+    ///
+    pub fn update_P<Data: MatrixProblemDataUpdate<T>>(
+        &mut self,
+        data: &Data,
+    ) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        let d = &self.data.equilibration.d;
+        data.update_matrix(&mut self.data.P, d, d)?;
+        // overwrite KKT data
+        self.kktsystem.update_P(&self.data.P);
+        Ok(())
+    }
+
+    /// Overwrites the `A` matrix data in an existing solver object.   The input `A` can be    
+    ///
+    /// - a nonempty Vector, in which case the nonzero values of the original `A` are overwritten, preserving the sparsity pattern, or
+    ///
+    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the original `A`.  
+    ///
+    /// - an iterator zip(&index,&values), specifying a selective update of values.
+    ///
+    /// - an empty vector, in which case no action is taken.
+    ///
+    pub fn update_A<Data: MatrixProblemDataUpdate<T>>(
+        &mut self,
+        data: &Data,
+    ) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        let d = &self.data.equilibration.d;
+        let e = &self.data.equilibration.e;
+        data.update_matrix(&mut self.data.A, e, d)?;
+        // overwrite KKT data
+        self.kktsystem.update_A(&self.data.A);
+        Ok(())
+    }
+
+    /// Overwrites the `q` vector data in an existing solver object.  No action is taken if the input is empty.
+    ///
+    //PJG: Error type is not ideal here.   Maybe need a generic user input
+    //error type, which can conatin a SparseFormatError or a PresolveDisabled error
+    pub fn update_q<Data: VectorProblemDataUpdate<T>>(
+        &mut self,
+        data: &Data,
+    ) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        let d = &self.data.equilibration.d;
+        let dinv = &self.data.equilibration.dinv;
+        data.update_vector(&mut self.data.q, d)?;
+
+        //recover unscaled norm
+        self.data.normq = self.data.q.norm_inf_scaled(dinv);
+
+        Ok(())
+    }
+
+    /// Overwrites the `b` vector data in an existing solver object.  No action is taken if the input is empty.
+    pub fn update_b<Data: VectorProblemDataUpdate<T>>(
+        &mut self,
+        data: &Data,
+    ) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        let e = &self.data.equilibration.e;
+        let einv = &self.data.equilibration.einv;
+        data.update_vector(&mut self.data.b, e)?;
+
+        //recover unscaled norm
+        self.data.normb = self.data.b.norm_inf_scaled(einv);
+
+        Ok(())
+    }
+
+    //PJG: This error type is incorrect.  Used in multiple places in this file
+    fn check_presolve_disabled(&self) -> Result<(), SparseFormatError> {
+        if self.settings.presolve_enable {
+            Err(SparseFormatError::IncompatibleDimension)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<T> MatrixProblemDataUpdate<T> for CscMatrix<T>
@@ -83,7 +204,7 @@ impl<T: FloatT> MatrixProblemDataUpdate<T> for [T; 0] {
 
 // Can't write a single impl for [T], Vec<T> and [T;0] above because
 // bounding by AsRef<[T]> is not specific enough to distinguish it from
-// the iterator case for partial updates implemented next.
+// the zip iterator for partial updates implemented next.
 
 impl<'a, T> MatrixProblemDataUpdate<T> for Zip<Iter<'a, usize>, Iter<'a, T>>
 where
@@ -95,21 +216,15 @@ where
         lscale: &[T],
         rscale: &[T],
     ) -> Result<(), SparseFormatError> {
-        for (&idx, &data) in self.clone() {
+        for (&idx, &value) in self.clone() {
             if idx >= M.nzval.len() {
                 return Err(SparseFormatError::IncompatibleDimension);
             }
             let (row, col) = M.index_to_coord(idx);
-            M.nzval[idx] = lscale[row] * rscale[col] * data;
+            M.nzval[idx] = lscale[row] * rscale[col] * value;
         }
         Ok(())
     }
-}
-
-// Trait for updating q and b vectors
-
-pub trait VectorProblemDataUpdate<T: FloatT> {
-    fn update_vector(&self, v: &mut [T], scale: &[T]) -> Result<(), SparseFormatError>;
 }
 
 impl<T> VectorProblemDataUpdate<T> for [T]
@@ -149,141 +264,19 @@ impl<T: FloatT> VectorProblemDataUpdate<T> for [T; 0] {
 
 // Can't write a single impl for [T], Vec<T> and [T;0] above because
 // bounding by AsRef<[T]> is not specific enough to distinguish it from
-// the iterator case for partial updates implemented next.
+// the zip iterator for partial updates implemented next.
 
 impl<'a, T> VectorProblemDataUpdate<T> for Zip<Iter<'a, usize>, Iter<'a, T>>
 where
     T: FloatT,
 {
     fn update_vector(&self, v: &mut [T], scale: &[T]) -> Result<(), SparseFormatError> {
-        for (&idx, &data) in self.clone() {
+        for (&idx, &value) in self.clone() {
             if idx >= v.len() {
                 return Err(SparseFormatError::IncompatibleDimension);
             }
-            v[idx] = data * scale[idx];
+            v[idx] = value * scale[idx];
         }
         Ok(())
-    }
-}
-
-impl<T> DefaultSolver<T>
-where
-    T: FloatT,
-{
-    /// Overwrites internal problem data structures in a solver object with new data, avoiding new memory allocations.   
-    /// See `update_P``, `update_q`, `update_A`, `update_b` for allowable inputs.
-
-    pub fn update_data<
-        DataP: MatrixProblemDataUpdate<T>,
-        Dataq: VectorProblemDataUpdate<T>,
-        DataA: MatrixProblemDataUpdate<T>,
-        Datab: VectorProblemDataUpdate<T>,
-    >(
-        &mut self,
-        P: &DataP,
-        q: &Dataq,
-        A: &DataA,
-        b: &Datab,
-    ) -> Result<(), SparseFormatError> {
-        self.update_P(P)?;
-        self.update_q(q)?;
-        self.update_A(A)?;
-        self.update_b(b)?;
-
-        Ok(())
-    }
-
-    /// Overwrites the `P` matrix data in an existing solver object.   The input `P` can be    
-    ///
-    /// - a nonempty Vector, in which case the nonzero values of the original `P` are overwritten, preserving the sparsity pattern, or
-    ///
-    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the upper triangular part of the original `P`.
-    ///
-    /// - an iterator zip(&index,&values), specifying a selective update of values.
-    ///
-    /// - an empty vector, in which case no action is taken.
-    ///
-    pub fn update_P<Data: MatrixProblemDataUpdate<T>>(
-        &mut self,
-        data: &Data,
-    ) -> Result<(), SparseFormatError> {
-        self.check_presolve_disabled()?;
-        data.update_matrix(
-            &mut self.data.P,
-            &self.data.equilibration.d,
-            &self.data.equilibration.d,
-        )?;
-        // overwrite KKT data
-        self.kktsystem.update_P(&self.data.P);
-        Ok(())
-    }
-
-    /// Overwrites the `A` matrix data in an existing solver object.   The input `A` can be    
-    ///
-    /// - a nonempty Vector, in which case the nonzero values of the original `A` are overwritten, preserving the sparsity pattern, or
-    ///
-    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the original `A`.  
-    ///
-    /// - an iterator zip(&index,&values), specifying a selective update of values.
-    ///
-    /// - an empty vector, in which case no action is taken.
-    ///
-    pub fn update_A<Data: MatrixProblemDataUpdate<T>>(
-        &mut self,
-        data: &Data,
-    ) -> Result<(), SparseFormatError> {
-        self.check_presolve_disabled()?;
-        data.update_matrix(
-            &mut self.data.A,
-            &self.data.equilibration.e,
-            &self.data.equilibration.d,
-        )?;
-        // overwrite KKT data
-        self.kktsystem.update_A(&self.data.A);
-        Ok(())
-    }
-
-    /// Overwrites the `q` vector data in an existing solver object.  No action is taken if the input is empty.
-    ///
-    //PJG: Error type is not ideal here.   Maybe need a generic user input
-    //error type, which can conatin a SparseFormatError or a PresolveDisabled error
-    pub fn update_q<Data: VectorProblemDataUpdate<T>>(
-        &mut self,
-        data: &Data,
-    ) -> Result<(), SparseFormatError> {
-        self.check_presolve_disabled()?;
-        let d = &self.data.equilibration.d;
-        let dinv = &self.data.equilibration.dinv;
-        data.update_vector(&mut self.data.q, d)?;
-
-        //recover unscaled norm
-        self.data.normq = self.data.q.norm_inf_scaled(dinv);
-
-        Ok(())
-    }
-
-    /// Overwrites the `b` vector data in an existing solver object.  No action is taken if the input is empty.
-    pub fn update_b<Data: VectorProblemDataUpdate<T>>(
-        &mut self,
-        data: &Data,
-    ) -> Result<(), SparseFormatError> {
-        self.check_presolve_disabled()?;
-        let e = &self.data.equilibration.e;
-        let einv = &self.data.equilibration.einv;
-        data.update_vector(&mut self.data.b, e)?;
-
-        //recover unscaled norm
-        self.data.normb = self.data.b.norm_inf_scaled(einv);
-
-        Ok(())
-    }
-
-    //PJG: This error type is incorrect.  Used in multiple places in this file
-    fn check_presolve_disabled(&self) -> Result<(), SparseFormatError> {
-        if self.settings.presolve_enable {
-            Err(SparseFormatError::IncompatibleDimension)
-        } else {
-            Ok(())
-        }
     }
 }

--- a/src/solver/implementations/default/data_updating.rs
+++ b/src/solver/implementations/default/data_updating.rs
@@ -1,0 +1,221 @@
+#![allow(non_snake_case)]
+use crate::algebra::*;
+use crate::solver::{scale_A, scale_P, scale_b, scale_q};
+use std::convert::From;
+
+use super::DefaultSolver;
+
+// Enum type allowing for flexible user input of matrix data updates.
+
+pub enum MatrixUpdateDataSource<'a, T: FloatT> {
+    CscMatrix(&'a CscMatrix<T>),
+    Slice(&'a [T]),
+}
+
+impl<'a, T> From<&'a [T]> for MatrixUpdateDataSource<'a, T>
+where
+    T: FloatT,
+{
+    fn from(v: &'a [T]) -> Self {
+        MatrixUpdateDataSource::Slice(v)
+    }
+}
+
+impl<'a, T> From<&'a Vec<T>> for MatrixUpdateDataSource<'a, T>
+where
+    T: FloatT,
+{
+    fn from(v: &'a Vec<T>) -> Self {
+        MatrixUpdateDataSource::Slice(v)
+    }
+}
+
+impl<'a, T> From<&'a [T; 0]> for MatrixUpdateDataSource<'a, T>
+where
+    T: FloatT,
+{
+    fn from(v: &'a [T; 0]) -> Self {
+        MatrixUpdateDataSource::Slice(v)
+    }
+}
+
+impl<'a, T> From<&'a CscMatrix<T>> for MatrixUpdateDataSource<'a, T>
+where
+    T: FloatT,
+{
+    fn from(v: &'a CscMatrix<T>) -> Self {
+        MatrixUpdateDataSource::CscMatrix(v)
+    }
+}
+
+impl<T> DefaultSolver<T>
+where
+    T: FloatT,
+{
+    /// Overwrites internal problem data structures in a solver object with new data, avoiding new memory allocations.   
+    /// See `update_P``, `update_q`, `update_A`, `update_b` for allowable inputs.
+
+    pub fn update_data<
+        'a,
+        CscOrSliceP: Into<MatrixUpdateDataSource<'a, T>>,
+        CscOrSliceA: Into<MatrixUpdateDataSource<'a, T>>,
+    >(
+        &mut self,
+        P: CscOrSliceP,
+        q: &[T],
+        A: CscOrSliceA,
+        b: &[T],
+    ) -> Result<(), SparseFormatError> {
+        self.update_P(P)?;
+        self.update_q(q)?;
+        self.update_A(A)?;
+        self.update_b(b)?;
+
+        Ok(())
+    }
+
+    /// Overwrites the `P` matrix data in an existing solver object.   The input `P` can be    
+    ///
+    /// - a nonempty Vector, in which case the nonzero values of the original `P` are overwritten, preserving the sparsity pattern, or
+    ///
+    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the upper triangular part of the original `P`.   
+    ///
+    /// - an empty vector, in which case no action is taken.
+    ///
+    pub fn update_P<'a, CscOrSlice: Into<MatrixUpdateDataSource<'a, T>>>(
+        &mut self,
+        data: CscOrSlice,
+    ) -> Result<(), SparseFormatError> {
+        let data = data.into();
+        match data {
+            MatrixUpdateDataSource::CscMatrix(P) => {
+                P.check_equal_sparsity(&self.data.P)?;
+                self.update_P_slice(&P.nzval)
+            }
+            MatrixUpdateDataSource::Slice(v) => self.update_P_slice(v),
+        }
+    }
+
+    fn update_P_slice(&mut self, v: &[T]) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        if v.is_empty() {
+            return Ok(());
+        }
+
+        if v.len() != self.data.P.nzval.len() {
+            return Err(SparseFormatError::IncompatibleDimension);
+        }
+
+        self.data.P.nzval.copy_from_slice(v);
+
+        // reapply original equilibration
+        scale_P(&mut self.data.P, &self.data.equilibration.d);
+
+        // overwrite KKT data
+        self.kktsystem.update_P(&self.data.P);
+        Ok(())
+    }
+
+    /// Overwrites the `A` matrix data in an existing solver object.   The input `A` can be    
+    ///
+    /// - a nonempty Vector, in which case the nonzero values of the original `A` are overwritten, preserving the sparsity pattern, or
+    ///
+    /// - a SparseMatrixCSC, in which case the input must match the sparsity pattern of the original `A`.   
+    ///
+    /// - an empty vector, in which case no action is taken.
+    ///
+    pub fn update_A<'a, CscOrVec: Into<MatrixUpdateDataSource<'a, T>>>(
+        &mut self,
+        data: CscOrVec,
+    ) -> Result<(), SparseFormatError> {
+        let data = data.into();
+        match data {
+            MatrixUpdateDataSource::CscMatrix(A) => {
+                A.check_equal_sparsity(&self.data.A)?;
+                self.update_A_slice(&A.nzval)
+            }
+            MatrixUpdateDataSource::Slice(v) => self.update_A_slice(v),
+        }
+    }
+
+    fn update_A_slice(&mut self, v: &[T]) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        if v.is_empty() {
+            return Ok(());
+        }
+
+        if v.len() != self.data.A.nzval.len() {
+            return Err(SparseFormatError::IncompatibleDimension);
+        }
+
+        self.data.A.nzval.copy_from_slice(v);
+
+        // reapply original equilibration
+        scale_A(
+            &mut self.data.A,
+            &self.data.equilibration.e,
+            &self.data.equilibration.d,
+        );
+
+        // overwrite KKT data
+        self.kktsystem.update_A(&self.data.A);
+
+        Ok(())
+    }
+
+    /// Overwrites the `q` vector data in an existing solver object.  No action is taken if the input is empty.
+    ///
+    //PJG: Error type is not ideal here.   Maybe need a generic user input
+    //error type, which can conatin a SparseFormatError or a PresolveDisabled error
+    pub fn update_q(&mut self, q: &[T]) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        if q.is_empty() {
+            return Ok(());
+        }
+
+        if q.len() != self.data.q.len() {
+            return Err(SparseFormatError::IncompatibleDimension);
+        }
+
+        self.data.q.copy_from_slice(q);
+
+        //recompute unscaled norm
+        self.data.normq = self.data.q.norm_inf();
+
+        //reapply original equilibration
+        scale_q(&mut self.data.q, &self.data.equilibration.d);
+
+        Ok(())
+    }
+
+    /// Overwrites the `b` vector data in an existing solver object.  No action is taken if the input is empty.
+    pub fn update_b(&mut self, b: &[T]) -> Result<(), SparseFormatError> {
+        self.check_presolve_disabled()?;
+        if b.is_empty() {
+            return Ok(());
+        }
+
+        if b.len() != self.data.b.len() {
+            return Err(SparseFormatError::IncompatibleDimension);
+        }
+
+        self.data.b.copy_from_slice(b);
+
+        //recompute unscaled norm
+        self.data.normb = self.data.b.norm_inf();
+
+        //reapply original equilibration
+        scale_b(&mut self.data.b, &self.data.equilibration.e);
+
+        Ok(())
+    }
+
+    //PJG: This error type is incorrect.  Used in multiple places in this file
+    fn check_presolve_disabled(&self) -> Result<(), SparseFormatError> {
+        if self.settings.presolve_enable {
+            Err(SparseFormatError::IncompatibleDimension)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -80,7 +80,7 @@ where
 
     fn update(
         &mut self,
-        data: &DefaultProblemData<T>,
+        data: &mut DefaultProblemData<T>,
         variables: &DefaultVariables<T>,
         residuals: &DefaultResiduals<T>,
         timers: &Timers,
@@ -88,6 +88,10 @@ where
         // optimality termination check should be computed w.r.t
         // the pre-homogenization x and z variables.
         let τinv = T::recip(variables.τ);
+
+        // unscaled linear term norms
+        let normb = data.get_normb();
+        let normq = data.get_normq();
 
         // shortcuts for the equilibration matrices
         let dinv = &data.equilibration.dinv;
@@ -109,9 +113,9 @@ where
 
         // primal and dual residuals.   Need to invert the equilibration
         self.res_primal =
-            residuals.rz.norm_scaled(einv) * τinv / T::max(T::one(), data.normb + normx + norms);
+            residuals.rz.norm_scaled(einv) * τinv / T::max(T::one(), normb + normx + norms);
         self.res_dual =
-            residuals.rx.norm_scaled(dinv) * τinv / T::max(T::one(), data.normq + normx + normz);
+            residuals.rx.norm_scaled(dinv) * τinv / T::max(T::one(), normq + normx + normz);
 
         // primal and dual infeasibility residuals.   Need to invert the equilibration
         self.res_primal_inf = residuals.rx_inf.norm_scaled(dinv) / T::max(T::one(), normz);

--- a/src/solver/implementations/default/kktsystem.rs
+++ b/src/solver/implementations/default/kktsystem.rs
@@ -266,4 +266,12 @@ where
 
         is_success
     }
+
+    pub(crate) fn update_P(&mut self, P: &CscMatrix<T>) {
+        self.kktsolver.update_P(P);
+    }
+
+    pub(crate) fn update_A(&mut self, A: &CscMatrix<T>) {
+        self.kktsolver.update_A(A);
+    }
 }

--- a/src/solver/implementations/default/mod.rs
+++ b/src/solver/implementations/default/mod.rs
@@ -3,6 +3,7 @@
 
 #![allow(non_snake_case)]
 
+mod data_updating;
 mod equilibration;
 mod info;
 mod info_print;
@@ -16,6 +17,7 @@ mod solver;
 mod variables;
 
 // export flattened
+pub use data_updating::*;
 pub use equilibration::*;
 pub use info::*;
 pub use info_print::*;

--- a/src/solver/implementations/default/problemdata.rs
+++ b/src/solver/implementations/default/problemdata.rs
@@ -197,13 +197,29 @@ fn scale_data<T: FloatT>(
 ) {
     match d {
         Some(d) => {
-            P.lrscale(d, d); // P[:,:] = Ds*P*Ds
-            A.lrscale(e, d); // A[:,:] = Es*A*Ds
-            q.hadamard(d);
+            scale_P(P, d);
+            scale_A(A, e, d);
+            scale_q(q, d);
         }
         None => {
             A.lscale(e); // A[:,:] = Es*A
         }
     }
+    scale_b(b, e);
+}
+
+pub(crate) fn scale_P<T: FloatT>(P: &mut CscMatrix<T>, d: &[T]) {
+    P.lrscale(d, d); // P[:,:] = Ds*P*Ds
+}
+
+pub(crate) fn scale_A<T: FloatT>(A: &mut CscMatrix<T>, e: &[T], d: &[T]) {
+    A.lrscale(e, d); // A[:,:] = Es*A
+}
+
+pub(crate) fn scale_q<T: FloatT>(q: &mut [T], d: &[T]) {
+    q.hadamard(d);
+}
+
+pub(crate) fn scale_b<T: FloatT>(b: &mut [T], e: &[T]) {
     b.hadamard(e);
 }

--- a/src/solver/implementations/default/problemdata.rs
+++ b/src/solver/implementations/default/problemdata.rs
@@ -197,29 +197,13 @@ fn scale_data<T: FloatT>(
 ) {
     match d {
         Some(d) => {
-            scale_P(P, d);
-            scale_A(A, e, d);
-            scale_q(q, d);
+            P.lrscale(d, d); // P[:,:] = Ds*P*Ds
+            A.lrscale(e, d);
+            q.hadamard(d);
         }
         None => {
             A.lscale(e); // A[:,:] = Es*A
         }
     }
-    scale_b(b, e);
-}
-
-pub(crate) fn scale_P<T: FloatT>(P: &mut CscMatrix<T>, d: &[T]) {
-    P.lrscale(d, d); // P[:,:] = Ds*P*Ds
-}
-
-pub(crate) fn scale_A<T: FloatT>(A: &mut CscMatrix<T>, e: &[T], d: &[T]) {
-    A.lrscale(e, d); // A[:,:] = Es*A
-}
-
-pub(crate) fn scale_q<T: FloatT>(q: &mut [T], d: &[T]) {
-    q.hadamard(d);
-}
-
-pub(crate) fn scale_b<T: FloatT>(b: &mut [T], e: &[T]) {
     b.hadamard(e);
 }

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -302,3 +302,30 @@ fn test_update_noops() {
     solver.update_data(&P2, &q2, &[], &[]).unwrap();
     solver.update_data(&[], &[], &A2, &b2).unwrap();
 }
+
+#[test]
+fn test_fail_on_presolve_enable() {
+    // original problem
+    let (P, q, A, b, cones, mut settings) = updating_test_data();
+    settings.presolve_enable = true;
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver.solve();
+
+    // apply no-op updates to check that updates are rejected
+    assert!(matches!(
+        solver.update_P(&[]).err(),
+        Some(DataUpdateError::PresolveEnabled)
+    ));
+    assert!(matches!(
+        solver.update_A(&[]).err(),
+        Some(DataUpdateError::PresolveEnabled)
+    ));
+    assert!(matches!(
+        solver.update_b(&[]).err(),
+        Some(DataUpdateError::PresolveEnabled)
+    ));
+    assert!(matches!(
+        solver.update_q(&[]).err(),
+        Some(DataUpdateError::PresolveEnabled)
+    ));
+}

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -1,0 +1,204 @@
+#![allow(non_snake_case)]
+
+use clarabel::{algebra::*, solver::*};
+
+#[allow(clippy::type_complexity)]
+fn updating_test_data() -> (
+    CscMatrix<f64>,
+    Vec<f64>,
+    CscMatrix<f64>,
+    Vec<f64>,
+    Vec<SupportedConeT<f64>>,
+    DefaultSettings<f64>,
+) {
+    // P = [4. 1;1 2]
+    let P = CscMatrix::from(&[
+        [4., 1.], //
+        [1., 2.], //
+    ]);
+
+    // A = [1 0; 0 1]; A = [-A;A]
+    let A = CscMatrix::identity(2);
+
+    let (mut A1, A2) = (A.clone(), A);
+    A1.negate();
+    let A = CscMatrix::vcat(&A1, &A2);
+
+    let q = vec![1.; 2];
+    let b = vec![1.; 4];
+
+    let cones = vec![NonnegativeConeT(2), NonnegativeConeT(2)];
+
+    let settings = DefaultSettingsBuilder::default()
+        .presolve_enable(false)
+        .equilibrate_enable(false)
+        .build()
+        .unwrap();
+
+    (P, q, A, b, cones, settings)
+}
+
+#[test]
+fn test_update_P_matrix_form() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    //solver1.solve();
+
+    // change P and re-solve
+    let mut P2 = P.clone();
+    P2.nzval[0] = 100.;
+
+    // revised original solver
+    assert!(solver1.update_P(&P2.to_triu()).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_P_vector_form() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // change P and re-solve
+    let mut P2 = P.clone();
+    P2.nzval[0] = 100.;
+
+    // revised original solver
+    assert!(solver1.update_P(&P2.to_triu().nzval).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_A_matrix_form() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    //solver1.solve();
+
+    // change A and re-solve
+    let mut A2 = A.clone();
+    A2.nzval[2] = -1000.;
+
+    // intention was to update the entry at position (1,1).  Did it work?
+    assert!(A2.get_entry((1, 1)).unwrap() == -1000.);
+
+    // revised original solver
+    assert!(solver1.update_A(&A2).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_A_vector_form() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // change A and re-solve
+    let mut A2 = A.clone();
+    A2.nzval[2] = -1000.;
+
+    // intention was to update the entry at position (1,1).  Did it work?
+    assert!(A2.get_entry((1, 1)).unwrap() == -1000.);
+
+    // revised original solver
+    assert!(solver1.update_A(&A2.nzval).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_q() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // change 1 and re-solve
+    let mut q2 = q.clone();
+    q2[0] = 1000.;
+
+    // revised original solver
+    assert!(solver1.update_q(&q2).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_b() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // change 1 and re-solve
+    let mut b2 = b.clone();
+    b2[0] = 0.;
+
+    // revised original solver
+    assert!(solver1.update_b(&b2).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_noops() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver.solve();
+
+    // apply no-op updates to check for crashes
+    solver.update_P(&[]).unwrap();
+    solver.update_A(&[]).unwrap();
+    solver.update_q(&[]).unwrap();
+    solver.update_b(&[]).unwrap();
+
+    // try noops in various combinations
+    let P2 = P.clone().to_triu();
+    let A2 = A.clone();
+    let b2 = b.clone();
+    let q2 = q.clone();
+
+    solver.update_data(&[], &[], &[], &[]).unwrap();
+    solver.update_data(&P2, &[], &A2, &[]).unwrap();
+    solver.update_data(&P2.nzval, &[], &A2.nzval, &[]).unwrap();
+    solver.update_data(&[], &q2, &[], &b2).unwrap();
+    solver.update_data(&P2, &q2, &[], &[]).unwrap();
+    solver.update_data(&[], &[], &A2, &b2).unwrap();
+}

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use std::iter::zip;
+
 use clarabel::{algebra::*, solver::*};
 
 #[allow(clippy::type_complexity)]
@@ -83,6 +85,31 @@ fn test_update_P_vector_form() {
 }
 
 #[test]
+fn test_update_P_tuple() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // revised original solver
+    let values = [3., 5.];
+    let index = [1, 2];
+    let Pdata = zip(&index, &values);
+    assert!(solver1.update_P(&Pdata).is_ok());
+    solver1.solve();
+
+    //new solver
+    let P2 = CscMatrix::from(&[
+        [4., 3.], //
+        [0., 5.], //
+    ]);
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
 fn test_update_A_matrix_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
@@ -141,13 +168,36 @@ fn test_update_q() {
 
     // change 1 and re-solve
     let mut q2 = q.clone();
-    q2[0] = 1000.;
+    q2[1] = 1000.;
 
     // revised original solver
     assert!(solver1.update_q(&q2).is_ok());
     solver1.solve();
 
     //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_q_tuple() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // revised original solver
+    let values = [1000.];
+    let index = [1];
+    let qdata = zip(&index, &values);
+    assert!(solver1.update_q(&qdata).is_ok());
+    solver1.solve();
+
+    //new solver
+    let mut q2 = q.clone();
+    q2[1] = 1000.;
     let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
     solver2.solve();
 
@@ -170,6 +220,28 @@ fn test_update_b() {
     solver1.solve();
 
     //new solver
+    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
+    solver2.solve();
+
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+}
+
+#[test]
+fn test_update_b_tuple() {
+    // original problem
+    let (P, q, A, b, cones, settings) = updating_test_data();
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    solver1.solve();
+
+    // revised original solver
+    let values = [0., 0.];
+    let index = [1, 3];
+    let bdata = zip(&index, &values);
+    assert!(solver1.update_b(&bdata).is_ok());
+    solver1.solve();
+
+    //new solver
+    let b2 = vec![1., 0., 1., 0.];
     let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
     solver2.solve();
 

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -46,11 +46,11 @@ fn test_update_P_matrix_form() {
     //solver1.solve();
 
     // change P and re-solve
-    let mut P2 = P.clone();
+    let mut P2 = P.to_triu();
     P2.nzval[0] = 100.;
 
     // revised original solver
-    assert!(solver1.update_P(&P2.to_triu()).is_ok());
+    assert!(solver1.update_P(&P2).is_ok());
     solver1.solve();
 
     //new solver
@@ -68,11 +68,11 @@ fn test_update_P_vector_form() {
     solver1.solve();
 
     // change P and re-solve
-    let mut P2 = P.clone();
+    let mut P2 = P.to_triu();
     P2.nzval[0] = 100.;
 
     // revised original solver
-    assert!(solver1.update_P(&P2.to_triu().nzval).is_ok());
+    assert!(solver1.update_P(&P2.nzval).is_ok());
     solver1.solve();
 
     //new solver
@@ -198,6 +198,7 @@ fn test_update_noops() {
     solver.update_data(&[], &[], &[], &[]).unwrap();
     solver.update_data(&P2, &[], &A2, &[]).unwrap();
     solver.update_data(&P2.nzval, &[], &A2.nzval, &[]).unwrap();
+    solver.update_data(&P2, &[], &A2.nzval, &[]).unwrap(); //mixed formats
     solver.update_data(&[], &q2, &[], &b2).unwrap();
     solver.update_data(&P2, &q2, &[], &[]).unwrap();
     solver.update_data(&[], &[], &A2, &b2).unwrap();

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -33,7 +33,7 @@ fn updating_test_data() -> (
 
     let settings = DefaultSettingsBuilder::default()
         .presolve_enable(false)
-        .equilibrate_enable(false)
+        .equilibrate_enable(true)
         .build()
         .unwrap();
 
@@ -59,7 +59,7 @@ fn test_update_P_matrix_form() {
     let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_update_P_vector_form() {
     let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn test_update_P_tuple() {
     let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_update_A_matrix_form() {
     let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn test_update_A_vector_form() {
     let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn test_update_A_tuple_form() {
     let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -192,7 +192,7 @@ fn test_update_q() {
 
     // change 1 and re-solve
     let mut q2 = q.clone();
-    q2[1] = 1000.;
+    q2[1] = 10.;
 
     // revised original solver
     assert!(solver1.update_q(&q2).is_ok());
@@ -202,7 +202,7 @@ fn test_update_q() {
     let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_update_q_tuple() {
     solver1.solve();
 
     // revised original solver
-    let values = [1000.];
+    let values = [10.];
     let index = [1];
     let qdata = zip(&index, &values);
     assert!(solver1.update_q(&qdata).is_ok());
@@ -221,11 +221,11 @@ fn test_update_q_tuple() {
 
     //new solver
     let mut q2 = q.clone();
-    q2[1] = 1000.;
+    q2[1] = 10.;
     let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -247,7 +247,7 @@ fn test_update_b() {
     let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn test_update_b_tuple() {
     let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
     solver2.solve();
 
-    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-6);
+    assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
 }
 
 #[test]


### PR DESCRIPTION
WIP : adds methods for updating P / q / A / b components of problem data in a solver, provided that the original sparsity patterns have not changed.

Addresses #59.   Not yet complete because it still requires C/C++/Python wrappers.