### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -171,10 +171,10 @@ jobs:
       - windows
       - linux
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: sdist
       - uses: actions/setup-python@v2

--- a/.github/workflows/testpypi.yaml
+++ b/.github/workflows/testpypi.yaml
@@ -160,10 +160,10 @@ jobs:
       - windows
       - linux
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: sdist
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Reverts oxfordcontrol/Clarabel.rs#86.   See also here: https://github.com/actions/upload-artifact/issues/472