### PR TITLE
Resolve lint warnings for rustc >=v1.75

### DIFF
--- a/src/algebra/csc/mod.rs
+++ b/src/algebra/csc/mod.rs
@@ -2,9 +2,6 @@
 
 mod core;
 pub use self::core::*;
-mod utils;
-pub use utils::*;
-mod matrix_math;
-pub use matrix_math::*;
 mod block_concatenate;
-pub use block_concatenate::*;
+mod matrix_math;
+mod utils;

--- a/src/algebra/dense/blaslike_traits.rs
+++ b/src/algebra/dense/blaslike_traits.rs
@@ -6,6 +6,7 @@ pub(crate) trait FactorEigen {
     // computes eigenvalues only (full set)
     fn eigvals(&mut self, A: &mut Matrix<Self::T>) -> Result<(), DenseFactorizationError>;
     // computes eigenvalues and vectors (full set)
+    #[allow(dead_code)] //PJG: not currently used anywhere
     fn eigen(&mut self, A: &mut Matrix<Self::T>) -> Result<(), DenseFactorizationError>;
 }
 
@@ -50,11 +51,13 @@ pub(crate) trait MultiplyGEMM {
         MATA: DenseMatrix<T = Self::T>;
 }
 
+#[allow(dead_code)] //PJG: not currently used anywhere
 pub(crate) trait MultiplyGEMV {
     type T;
     fn gemv(&self, x: &[Self::T], y: &mut [Self::T], α: Self::T, β: Self::T);
 }
 
+#[allow(dead_code)] //PJG: not currently used anywhere
 pub(crate) trait MultiplySYMV {
     type T;
     fn symv(&self, x: &[Self::T], y: &mut [Self::T], α: Self::T, β: Self::T);

--- a/src/algebra/dense/block_concatenate.rs
+++ b/src/algebra/dense/block_concatenate.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 use crate::algebra::{BlockConcatenate, FloatT, Matrix, ShapedMatrix};
-use std::iter::Extend;
 
 impl<T> BlockConcatenate for Matrix<T>
 where

--- a/src/algebra/dense/mod.rs
+++ b/src/algebra/dense/mod.rs
@@ -1,9 +1,7 @@
 mod core;
 pub use self::core::*;
 mod block_concatenate;
-pub use block_concatenate::*;
 mod matrix_math;
-pub use matrix_math::*;
 
 mod blaslike_traits;
 pub(crate) use blaslike_traits::*;

--- a/src/algebra/densesym3x3/mod.rs
+++ b/src/algebra/densesym3x3/mod.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use super::FloatT;
 use crate::algebra::*;
 use std::ops::{Index, IndexMut};
 

--- a/src/algebra/matrix_traits.rs
+++ b/src/algebra/matrix_traits.rs
@@ -7,6 +7,7 @@ use crate::algebra::MatrixShape;
 pub(crate) trait ShapedMatrix {
     fn nrows(&self) -> usize;
     fn ncols(&self) -> usize;
+    #[allow(dead_code)] //PJG: not currently used anywhere
     fn shape(&self) -> MatrixShape;
     fn size(&self) -> (usize, usize) {
         (self.nrows(), self.ncols())
@@ -20,6 +21,7 @@ pub(crate) trait ShapedMatrix {
 //is implemented on Matrix, Adjoint and ReshapedMatrix to allow for indexing
 //of values in any of those format.   This follows the Julia naming convention
 //for similar types.
+#[allow(dead_code)] //PJG: not currently used anywhere
 pub(crate) trait DenseMatrix: ShapedMatrix + Index<(usize, usize)> {
     type T;
     fn index_linear(&self, idx: (usize, usize)) -> usize;

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -21,16 +21,12 @@ mod reshaped;
 mod scalarmath;
 mod symmetric;
 mod vecmath;
-pub use adjoint::*;
 pub use error_types::*;
 pub use floats::*;
 pub use math_traits::*;
 pub use matrix_traits::*;
 pub use matrix_types::*;
-pub use reshaped::*;
 pub(crate) use scalarmath::*;
-pub use symmetric::*;
-pub use vecmath::*;
 
 // matrix implementations
 mod csc;

--- a/src/qdldl/test.rs
+++ b/src/qdldl/test.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::algebra::{CscMatrix, FloatT};
 extern crate amd;
 
 #[cfg(test)]

--- a/src/solver/core/cones/compositecone.rs
+++ b/src/solver/core/cones/compositecone.rs
@@ -67,7 +67,7 @@ where
         let degree = cones.iter().map(|c| c.degree()).sum();
 
         //ranges for the subvectors associated with each cone,
-        //and the rangse for with the corresponding entries
+        //and the ranges for the corresponding entries
         //in the Hs sparse block
 
         let rng_cones = _make_rng_cones(&cones);
@@ -125,19 +125,6 @@ where
         }
     }
     rngs
-}
-
-fn _make_headidx<T>(headidx: &mut [usize], cones: &[SupportedCone<T>])
-where
-    T: FloatT,
-{
-    if !cones.is_empty() {
-        // index of first element in each cone
-        headidx[0] = 0;
-        for i in 2..headidx.len() {
-            headidx[i] = headidx[i - 1] + cones[i - 1].numel();
-        }
-    }
 }
 
 impl<T> CompositeCone<T>

--- a/src/solver/core/cones/compositecone.rs
+++ b/src/solver/core/cones/compositecone.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::algebra::triangular_number;
-use crate::solver::CoreSettings;
 use std::collections::HashMap;
 use std::iter::zip;
 use std::ops::Range;

--- a/src/solver/core/cones/expcone.rs
+++ b/src/solver/core/cones/expcone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 
 // -------------------------------------
 // Exponential Cone

--- a/src/solver/core/cones/genpowcone.rs
+++ b/src/solver/core/cones/genpowcone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 use itertools::izip;
 use std::iter::zip;
 

--- a/src/solver/core/cones/nonnegativecone.rs
+++ b/src/solver/core/cones/nonnegativecone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 use itertools::izip;
 use std::iter::zip;
 

--- a/src/solver/core/cones/powcone.rs
+++ b/src/solver/core/cones/powcone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 
 // -------------------------------------
 // Power Cone

--- a/src/solver/core/cones/psdtrianglecone.rs
+++ b/src/solver/core/cones/psdtrianglecone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 
 // ------------------------------------
 // Positive Semidefinite Cone (Scaled triangular form)

--- a/src/solver/core/cones/socone.rs
+++ b/src/solver/core/cones/socone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 use itertools::izip;
 
 // -------------------------------------

--- a/src/solver/core/cones/supportedcone.rs
+++ b/src/solver/core/cones/supportedcone.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::algebra::FloatT;
 
 #[cfg(feature = "sdp")]
 use crate::algebra::triangular_number;

--- a/src/solver/core/cones/symmetric_common.rs
+++ b/src/solver/core/cones/symmetric_common.rs
@@ -1,4 +1,4 @@
-use crate::algebra::{FloatT, MatrixShape, VectorMath};
+use crate::algebra::{MatrixShape, VectorMath};
 
 use super::*;
 
@@ -15,11 +15,13 @@ pub trait SymmetricCone<T: FloatT>: JordanAlgebra<T> {
     // x = λ \ z
     // Included as a special case since q \ z for general q is difficult
     // to implement for general q i PSD cone and never actually needed.
+    #[allow(dead_code)] //PJG: not currently used anywhere
     fn λ_inv_circ_op(&mut self, x: &mut [T], z: &[T]);
 }
 
 pub trait JordanAlgebra<T: FloatT> {
     fn circ_op(&mut self, x: &mut [T], y: &[T], z: &[T]);
+    #[allow(dead_code)] //PJG: inv_circ_op not needed anywhere.  keep for symmetry
     fn inv_circ_op(&mut self, x: &mut [T], y: &[T], z: &[T]);
 }
 

--- a/src/solver/core/cones/zerocone.rs
+++ b/src/solver/core/cones/zerocone.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    algebra::*,
-    solver::{core::ScalingStrategy, CoreSettings},
-};
+use crate::algebra::*;
 use core::marker::PhantomData;
 
 // -------------------------------------

--- a/src/solver/core/kktsolvers/direct/quasidef/kkt_assembly.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/kkt_assembly.rs
@@ -2,7 +2,6 @@
 
 use super::datamaps::*;
 use crate::algebra::*;
-use crate::solver::core::cones::CompositeCone;
 use crate::solver::core::cones::*;
 use num_traits::Zero;
 

--- a/src/solver/core/kktsolvers/direct/quasidef/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/mod.rs
@@ -14,6 +14,7 @@ use kkt_assembly::*;
 pub trait DirectLDLSolver<T: FloatT> {
     fn update_values(&mut self, index: &[usize], values: &[T]);
     fn scale_values(&mut self, index: &[usize], scale: T);
+    #[allow(dead_code)] //PJG: could be removed.
     fn offset_values(&mut self, index: &[usize], offset: T, signs: &[i8]);
     fn solve(&mut self, x: &mut [T], b: &[T]);
     fn refactor(&mut self, kkt: &CscMatrix<T>) -> bool;

--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -391,7 +391,6 @@ where
 // Encapsulate the internal helpers trait in a private module
 // so it doesn't get exported
 mod internal {
-    use super::super::cones::Cone;
     use super::super::traits::*;
     use super::*;
 

--- a/src/solver/implementations/default/info_print.rs
+++ b/src/solver/implementations/default/info_print.rs
@@ -37,13 +37,14 @@ where
         cones: &CompositeCone<T>,
     ) -> std::io::Result<()> {
         if !settings.verbose {
-            return std::io::Result::Ok(())
+            return std::io::Result::Ok(());
         }
 
         let mut out = stdio::stdout();
 
         if data.presolver.is_reduced() {
-            writeln!(out, 
+            writeln!(
+                out,
                 "\npresolve: removed {} constraints",
                 data.presolver.count_reduced()
             )?;
@@ -66,16 +67,16 @@ where
         #[cfg(feature = "sdp")]
         _print_conedims_by_type(cones, SupportedConeTag::PSDTriangleCone)?;
 
-        writeln!(out, )?;
+        writeln!(out,)?;
         _print_settings(settings)?;
-        writeln!(out, )?;
+        writeln!(out,)?;
 
         std::io::Result::Ok(())
     }
 
     fn print_status_header(&self, settings: &DefaultSettings<T>) -> std::io::Result<()> {
         if !settings.verbose {
-            return std::io::Result::Ok(())
+            return std::io::Result::Ok(());
         }
 
         let mut out = stdio::stdout();
@@ -90,8 +91,8 @@ where
         write!(out, "k/t       ")?;
         write!(out, " μ       ")?;
         write!(out, "step      ")?;
-        writeln!(out, )?;
-        writeln!(out, 
+        writeln!(out,)?;
+        writeln!(out,
             "---------------------------------------------------------------------------------------------"
         )?;
         stdio::stdout().flush()?;
@@ -121,7 +122,7 @@ where
             write!(out, " ------   ")?; //info.step_length
         }
 
-        writeln!(out, )?;
+        writeln!(out,)?;
 
         std::io::Result::Ok(())
     }
@@ -133,13 +134,14 @@ where
 
         let mut out = stdio::stdout();
 
-        writeln!(out, 
+        writeln!(out,
             "---------------------------------------------------------------------------------------------"
         )?;
 
         writeln!(out, "Terminated with status = {}", self.status)?;
 
-        writeln!(out, 
+        writeln!(
+            out,
             "solve time = {:?}",
             Duration::from_secs_f64(self.solve_time)
         )?;
@@ -155,14 +157,15 @@ fn _bool_on_off(v: bool) -> &'static str {
     }
 }
 
-fn _print_settings<T: FloatT>(settings: &DefaultSettings<T>) -> std::io::Result<()>{
+fn _print_settings<T: FloatT>(settings: &DefaultSettings<T>) -> std::io::Result<()> {
     let set = settings;
     let mut out = stdio::stdout();
 
     writeln!(out, "settings:")?;
 
     if set.direct_kkt_solver {
-        writeln!(out, 
+        writeln!(
+            out,
             "  linear algebra: direct / {}, precision: {} bit",
             set.direct_solve_method,
             _get_precision_string::<T>()
@@ -176,50 +179,61 @@ fn _print_settings<T: FloatT>(settings: &DefaultSettings<T>) -> std::io::Result<
             format!("{:?}", set.time_limit)
         }
     };
-    writeln!(out, 
+    writeln!(
+        out,
         "  max iter = {}, time limit = {},  max step = {:.3}",
         set.max_iter, time_lim_str, set.max_step_fraction
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "  tol_feas = {:.1e}, tol_gap_abs = {:.1e}, tol_gap_rel = {:.1e},",
         set.tol_feas, set.tol_gap_abs, set.tol_gap_rel
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "  static reg : {}, ϵ1 = {:.1e}, ϵ2 = {:.1e}",
         _bool_on_off(set.static_regularization_enable),
         set.static_regularization_constant,
         set.static_regularization_proportional,
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "  dynamic reg: {}, ϵ = {:.1e}, δ = {:.1e}",
         _bool_on_off(set.dynamic_regularization_enable),
         set.dynamic_regularization_eps,
         set.dynamic_regularization_delta
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "  iter refine: {}, reltol = {:.1e}, abstol = {:.1e},",
         _bool_on_off(set.iterative_refinement_enable),
         set.iterative_refinement_reltol,
         set.iterative_refinement_abstol
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "               max iter = {}, stop ratio = {:.1}",
         set.iterative_refinement_max_iter, set.iterative_refinement_stop_ratio
     )?;
 
-    writeln!(out, 
+    writeln!(
+        out,
         "  equilibrate: {}, min_scale = {:.1e}, max_scale = {:.1e}",
         _bool_on_off(set.equilibrate_enable),
         set.equilibrate_min_scaling,
         set.equilibrate_max_scaling
     )?;
 
-    writeln!(out, "               max iter = {}", set.equilibrate_max_iter,)?;
+    writeln!(
+        out,
+        "               max iter = {}",
+        set.equilibrate_max_iter,
+    )?;
 
     std::io::Result::Ok(())
 }
@@ -228,14 +242,17 @@ fn _get_precision_string<T: FloatT>() -> String {
     (::std::mem::size_of::<T>() * 8).to_string()
 }
 
-fn _print_conedims_by_type<T: FloatT>(cones: &CompositeCone<T>, conetag: SupportedConeTag) -> std::io::Result<()> {
+fn _print_conedims_by_type<T: FloatT>(
+    cones: &CompositeCone<T>,
+    conetag: SupportedConeTag,
+) -> std::io::Result<()> {
     let maxlistlen = 5;
 
     let count = cones.get_type_count(conetag);
 
     //skip if there are none of this type
     if count == 0 {
-        return std::io::Result::Ok(())
+        return std::io::Result::Ok(());
     }
 
     let mut out = stdio::stdout();
@@ -273,7 +290,7 @@ fn _print_conedims_by_type<T: FloatT>(cones: &CompositeCone<T>, conetag: Support
         write!(out, "...,{})", nvars[nvars.len() - 1])?;
     }
 
-    writeln!(out, )?;
+    writeln!(out,)?;
 
     std::io::Result::Ok(())
 }

--- a/src/solver/implementations/default/mod.rs
+++ b/src/solver/implementations/default/mod.rs
@@ -20,7 +20,6 @@ mod variables;
 pub use data_updating::*;
 pub use equilibration::*;
 pub use info::*;
-pub use info_print::*;
 pub use kktsystem::*;
 pub use presolver::*;
 pub use problemdata::*;


### PR DESCRIPTION
Resolves new linter warnings in v1.75, most of which relate to redundant imports or unused functions.   Fix for #83.