### PR TITLE
Update pypi.yaml

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -62,7 +62,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
don't prescribe macos-latest architecture