### PR TITLE
Update pypi.yaml

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -55,7 +55,7 @@ jobs:
 
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     # if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Change from macos-latest to macos-13 since older versions of python were are seemingly not available for macos-latest.

Relevant issue and suggested fix from here: https://github.com/actions/setup-python/issues/855