### PR TITLE
force mkl LP64 format (32 bit ints)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ sdp = ["blas","lapack", "indexmap"]
 sdp-accelerate = ["sdp", "blas-src/accelerate", "lapack-src/accelerate"]
 sdp-netlib     = ["sdp", "blas-src/netlib", "lapack-src/netlib"]
 sdp-openblas   = ["sdp", "blas-src/openblas", "lapack-src/openblas"]
-sdp-mkl        = ["sdp", "blas-src/intel-mkl", "lapack-src/intel-mkl"]
+sdp-mkl        = ["sdp", "blas-src/intel-mkl", "lapack-src/intel-mkl","intel-mkl-src"]
 sdp-r          = ["sdp", "blas-src/r", "lapack-src/r"]
 
 
@@ -79,6 +79,11 @@ optional = true
 [dependencies.lapack-src]
 version = "0.10"
 optional = true 
+
+[dependencies.intel-mkl-src]
+version = "0.8.1"
+features = ["mkl-static-lp64-iomp"]
+optional = true
 
 [dependencies.indexmap]
 version = "2.2"


### PR DESCRIPTION
Fixes an occasional issue with MKL compilation by specifying that we want to use the LP64 format, i.e. 32 bit integer types.   