### PR TITLE
Fix compilation failure without "serde" feature

### DIFF
--- a/src/algebra/csc/core.rs
+++ b/src/algebra/csc/core.rs
@@ -42,7 +42,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 ///
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(bound = "T: Serialize + DeserializeOwned")]
+#[cfg_attr(feature = "serde", serde(bound = "T: Serialize + DeserializeOwned"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CscMatrix<T = f64> {
     /// number of rows

--- a/src/solver/implementations/default/settings.rs
+++ b/src/solver/implementations/default/settings.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[derive(Builder, Debug, Clone)]
 #[builder(build_fn(validate = "Self::validate"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(bound = "T: Serialize + DeserializeOwned")]
+#[cfg_attr(feature = "serde", serde(bound = "T: Serialize + DeserializeOwned"))]
 pub struct DefaultSettings<T: FloatT> {
     ///maximum number of iterations
     #[builder(default = "200")]


### PR DESCRIPTION
Compilation currently fails without the "serde" feature enabled because the use of `#[serde(...)]` isn't conditioned on the feature being enabled. This PR uses `cfg_attr` to do so similar to the `Serialize` and `Deserialize` derives.