### PR TITLE
Using .dlext directly from Libdl rather than Base.Libc

### DIFF
--- a/src/julia/ClarabelRs/src/ClarabelRs.jl
+++ b/src/julia/ClarabelRs/src/ClarabelRs.jl
@@ -13,7 +13,7 @@ module ClarabelRs
         # > cargo build --release --features julia
         global libpath = joinpath(@__DIR__, 
                         "../../../../target/release/",
-                        "libclarabel." * Base.Libc.dlext
+                        "libclarabel." * Libdl.dlext
                 )
         global librust = Libdl.dlopen(libpath)
     end


### PR DESCRIPTION
This line broke for me when using ClarabelRs on Julia 1.11.

In previous releases of Julia it seems at you could dlext from Base.Libc.dlext, but this seems to not be the case on 1.11 (at least on macOS). Since Libdl is loaded here one can instead get dlext from Libdl.dlext.