### PR TITLE
Add WebAssembly example for Clarabel.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,10 @@ name = "json"
 path = "examples/rust/example_json.rs"
 required-features = ["serde"]
 
-
+[[example]]
+name = "example_wasm"
+path = "examples/rust/example_wasm.rs"
+required-features = ["wasm"]
 
 
 # -------------------------------

--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ pip install clarabel
 
 To install the Python interface from source, see the [Python Installation Documentation](https://oxfordcontrol.github.io/ClarabelDocs/stable/python/installation_py/).
 
+## Building and Running the WebAssembly Example
+
+To build and run the WebAssembly example, follow these steps:
+
+1. Ensure you have `wasm-pack` installed. If not, you can install it using:
+   ```
+   cargo install wasm-pack
+   ```
+
+2. Build the WebAssembly example:
+   ```
+   wasm-pack build --target web --features wasm --example example_wasm
+   ```
+
+3. Serve the generated files using a web server. For example, you can use `basic-http-server`:
+   ```
+   cargo install basic-http-server
+   basic-http-server ./pkg
+   ```
+
+4. Open your web browser and navigate to the address provided by the web server to see the example in action.
+
 ## Citing
 ```
 @misc{Clarabel_2024,

--- a/examples/rust/example_wasm.rs
+++ b/examples/rust/example_wasm.rs
@@ -1,0 +1,40 @@
+use clarabel::algebra::*;
+use clarabel::solver::*;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn solve_problem() -> Result<(), JsValue> {
+    let (P, q, A, b) = problem_data();
+
+    let cones = [NonnegativeConeT(b.len())];
+
+    let settings = DefaultSettingsBuilder::default()
+        .equilibrate_enable(true)
+        .max_iter(50)
+        .build()
+        .map_err(|e| JsValue::from_str(&format!("Settings error: {:?}", e)))?;
+
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+
+    solver.solve();
+
+    Ok(())
+}
+
+fn problem_data() -> (CscMatrix<f64>, Vec<f64>, CscMatrix<f64>, Vec<f64>) {
+    let n = 2000000;
+
+    let P = CscMatrix::identity(n);
+
+    // construct A = [I; -I]
+    let I1 = CscMatrix::<f64>::identity(n);
+    let mut I2 = CscMatrix::<f64>::identity(n);
+    I2.negate();
+
+    let A = CscMatrix::vcat(&I1, &I2);
+
+    let q = vec![1.; n];
+    let b = vec![1.; 2 * n];
+
+    (P, q, A, b)
+}


### PR DESCRIPTION
Add WebAssembly example and update documentation.

* **Cargo.toml**
  - Add a new example `example_wasm` under the `[[example]]` section with the `wasm` feature enabled.

* **README.md**
  - Add instructions for building and running the WebAssembly example.

* **examples/rust/example_wasm.rs**
  - Add a new example demonstrating the usage of the solver in a WebAssembly environment.

