### PR TITLE
Python 3.7/3.8 EOL update

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   PACKAGE_NAME: clarabel
-  PYTHON_VERSION: "3.7" # to build abi3 wheels
+  PYTHON_VERSION: "3.9" # to build abi3 wheels
   PYPI_TARGET: pypi # use "testpypi" for testing, "pypi" otherwise
 
 # NB: uncomment "if" lines below to skip compilation except on version tagging

--- a/.github/workflows/testpypi.yaml
+++ b/.github/workflows/testpypi.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   PACKAGE_NAME: clarabel
-  PYTHON_VERSION: "3.7" # to build abi3 wheels
+  PYTHON_VERSION: "3.9" # to build abi3 wheels
   PYPI_TARGET: testpypi # use "testpypi" for testing, "pypi" otherwise
 
 # NB: uncomment "if" lines below to skip compilation except on version tagging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,8 +177,8 @@ version = "0.2"
 optional = true
 version = "0.20"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
-# "abi3-py37" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
-features = ["extension-module", "abi3-py37"]
+# "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
+features = ["extension-module", "abi3-py39"]
 
 [lib]
 name = "clarabel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ version = "0.2"
 
 [dependencies.pyo3]
 optional = true
-version = "0.20"
+version = "0.22"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
 features = ["extension-module", "abi3-py39"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ version = "0.2"
 
 [dependencies.pyo3]
 optional = true
-version = "0.22"
+version = "0.23"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
 features = ["extension-module", "abi3-py39"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "clarabel"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "scipy"

--- a/src/algebra/floats.rs
+++ b/src/algebra/floats.rs
@@ -13,6 +13,7 @@ use crate::algebra::dense::BlasFloatT;
 pub trait CoreFloatT:
     'static
     + Send
+    + Sync
     + Float
     + FloatConst
     + NumAssign
@@ -28,6 +29,7 @@ pub trait CoreFloatT:
 impl<T> CoreFloatT for T where
     T: 'static
         + Send
+        + Sync
         + Float
         + FloatConst
         + NumAssign

--- a/src/python/cones_py.rs
+++ b/src/python/cones_py.rs
@@ -161,10 +161,11 @@ impl From<PySupportedCone> for SupportedConeT<f64> {
 }
 
 impl<'a> FromPyObject<'a> for PySupportedCone {
-    fn extract(obj: &'a PyAny) -> PyResult<Self> {
+    fn extract_bound(obj: &Bound<'a, pyo3::PyAny>) -> PyResult<Self> {
         let thetype = obj.get_type().name()?;
+        let typestr = thetype.to_string_lossy();
 
-        match thetype {
+        match typestr.as_ref() {
             "ZeroConeT" => {
                 let dim: usize = obj.getattr("dim")?.extract()?;
                 Ok(PySupportedCone(ZeroConeT(dim)))

--- a/src/python/cscmatrix_py.rs
+++ b/src/python/cscmatrix_py.rs
@@ -21,7 +21,7 @@ impl From<PyCscMatrix> for CscMatrix<f64> {
 }
 
 impl<'a> FromPyObject<'a> for PyCscMatrix {
-    fn extract(obj: &'a PyAny) -> PyResult<Self> {
+    fn extract_bound(obj: &Bound<'a, pyo3::PyAny>) -> PyResult<Self> {
         let nzval: Vec<f64> = obj.getattr("data")?.extract()?;
         let rowval: Vec<usize> = obj.getattr("indices")?.extract()?;
         let colptr: Vec<usize> = obj.getattr("indptr")?.extract()?;

--- a/src/python/impl_default_py.rs
+++ b/src/python/impl_default_py.rs
@@ -12,8 +12,6 @@ use crate::solver::{
     implementations::default::*,
     SolverJSONReadWrite,
 };
-use num_derive::ToPrimitive;
-use num_traits::ToPrimitive;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use std::fmt::Write;
@@ -91,8 +89,8 @@ impl PyDefaultSolution {
 // Solver Status
 // ----------------------------------
 
-#[derive(PartialEq, Debug, Clone, ToPrimitive)]
-#[pyclass(name = "SolverStatus")]
+#[derive(PartialEq, Debug, Clone, Copy)]
+#[pyclass(eq, eq_int, name = "SolverStatus")]
 pub enum PySolverStatus {
     Unsolved = 0,
     Solved,
@@ -146,7 +144,7 @@ impl PySolverStatus {
 
     // mapping of solver status to CVXPY keys is done via a hash
     pub fn __hash__(&self) -> u32 {
-        self.to_u32().unwrap()
+        *self as u32
     }
 }
 

--- a/src/python/io.rs
+++ b/src/python/io.rs
@@ -1,7 +1,7 @@
 // Provides a Writer to allow for redirection of stdout and stderr streams
 // to the ones configured for Python.
 
-use pyo3::ffi::{PySys_WriteStderr, PySys_WriteStdout};
+use pyo3::ffi::{c_str, PySys_WriteStderr, PySys_WriteStdout};
 use pyo3::prelude::*;
 use std::io::{LineWriter, Write};
 use std::os::raw::c_char;
@@ -33,8 +33,8 @@ macro_rules! make_python_stdio {
             fn flush(&mut self) -> std::io::Result<()> {
                 // call the python flush() on sys.$pymodname
                 Python::with_gil(|py| -> std::io::Result<()> {
-                    py.run_bound(
-                        std::concat!("import sys; sys.", $pymodname, ".flush()"),
+                    py.run(
+                        c_str!(std::concat!("import sys; sys.", $pymodname, ".flush()")),
                         None,
                         None,
                     )

--- a/src/python/io.rs
+++ b/src/python/io.rs
@@ -33,7 +33,7 @@ macro_rules! make_python_stdio {
             fn flush(&mut self) -> std::io::Result<()> {
                 // call the python flush() on sys.$pymodname
                 Python::with_gil(|py| -> std::io::Result<()> {
-                    py.run(
+                    py.run_bound(
                         std::concat!("import sys; sys.", $pymodname, ".flush()"),
                         None,
                         None,

--- a/src/python/module_py.rs
+++ b/src/python/module_py.rs
@@ -24,7 +24,7 @@ fn default_infinity_py() {
 // Python module and registry, which includes registration of the
 // data types defined in the other files in this rust module
 #[pymodule]
-fn clarabel(_py: Python, m: &PyModule) -> PyResult<()> {
+fn clarabel(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     //module version
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 

--- a/src/python/pyblas/mod.rs
+++ b/src/python/pyblas/mod.rs
@@ -38,7 +38,7 @@ fn get_capsule_void_ptr(pyx_capi: &Bound<PyAny>, name: &str) -> PyResult<*mut li
 }
 
 fn get_pyx_capi<'a>(py: Python<'a>, pymodule: &str) -> PyResult<Bound<'a, PyAny>> {
-    let lib = PyModule::import_bound(py, pymodule)?;
+    let lib = PyModule::import(py, pymodule)?;
     let api = lib.getattr("__pyx_capi__")?;
     Ok(api)
 }

--- a/src/python/pyblas/mod.rs
+++ b/src/python/pyblas/mod.rs
@@ -26,18 +26,19 @@ pub fn force_load() {
 // utilities for scipy blas/lapack import
 macro_rules! get_ptr {
     ($api: ident, $str: tt) => {
-        std::mem::transmute(get_capsule_void_ptr($api, $str)?)
+        std::mem::transmute(get_capsule_void_ptr(&$api, $str)?)
     };
 }
 pub(crate) use get_ptr;
 
-fn get_capsule_void_ptr(pyx_capi: &PyAny, name: &str) -> PyResult<*mut libc::c_void> {
-    let capsule: &PyCapsule = pyx_capi.get_item(name)?.downcast()?;
+fn get_capsule_void_ptr(pyx_capi: &Bound<PyAny>, name: &str) -> PyResult<*mut libc::c_void> {
+    let binding = pyx_capi.get_item(name)?;
+    let capsule: &Bound<PyCapsule> = binding.downcast()?;
     Ok(capsule.pointer())
 }
 
-fn get_pyx_capi<'a>(py: Python<'a>, pymodule: &str) -> PyResult<&'a PyAny> {
-    let lib = PyModule::import(py, pymodule)?;
+fn get_pyx_capi<'a>(py: Python<'a>, pymodule: &str) -> PyResult<Bound<'a, PyAny>> {
+    let lib = PyModule::import_bound(py, pymodule)?;
     let api = lib.getattr("__pyx_capi__")?;
     Ok(api)
 }

--- a/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
@@ -13,10 +13,10 @@ use std::iter::zip;
 // KKTSolver using direct LDL factorisation
 // -------------------------------------
 
-// We require Send here to allow pyo3 builds to share
+// We require Send/Sync here to allow pyo3 builds to share
 // solver objects between threads.
 
-pub(crate) type BoxedDirectLDLSolver<T> = Box<dyn DirectLDLSolver<T> + Send>;
+pub(crate) type BoxedDirectLDLSolver<T> = Box<dyn DirectLDLSolver<T> + Send + Sync>;
 
 pub struct DirectLDLKKTSolver<T> {
     // problem dimensions

--- a/src/solver/implementations/default/kktsystem.rs
+++ b/src/solver/implementations/default/kktsystem.rs
@@ -8,10 +8,10 @@ use crate::solver::core::{
 
 use crate::algebra::*;
 
-// We require Send here to allow pyo3 builds to share
+// We require Send/Sync here to allow pyo3 builds to share
 // solver objects between threads.
 
-type BoxedKKTSolver<T> = Box<dyn KKTSolver<T> + Send>;
+type BoxedKKTSolver<T> = Box<dyn KKTSolver<T> + Send + Sync>;
 
 /// Standard-form solver type implementing the [`KKTSystem`](crate::solver::core::traits::KKTSystem) trait
 


### PR DESCRIPTION
Produce python abi3 outputs with MSV python 3.9.   This remains compatible with cvxpy, which also requires >= 3.9.

Updating now since some CI builds have begun failing on `ubuntu-latest` with python 3.7.

Internal updates for compatibility with pyo3 v0.23 to support python 3.13.

Fixes #146 