### PR TITLE
update faer version to v.0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,12 +89,16 @@ optional = true
 version = "2.2"
 optional = true
 
+# -------------------------------
+# 3rd party sparse LDL solvers
+# -------------------------------
+
 [dependencies.faer]
-version = "0.19"
+version = "0.20"
 optional = true 
 
 [dependencies.faer-entity]
-version = "0.19"
+version = "0.20"
 optional = true 
 
 

--- a/src/solver/core/kktsolvers/direct/quasidef/datamaps.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/datamaps.rs
@@ -19,11 +19,11 @@ where
     GenPowerCone(&'a GenPowerCone<T>),
 }
 
-impl<'a, T> SupportedCone<T>
+impl<T> SupportedCone<T>
 where
     T: FloatT,
 {
-    pub(crate) fn to_sparse_expansion(&'a self) -> Option<SparseExpansionCone<T>> {
+    pub(crate) fn to_sparse_expansion(&self) -> Option<SparseExpansionCone<T>> {
         match self {
             SupportedCone::SecondOrderCone(sc) => Some(SparseExpansionCone::SecondOrderCone(sc)),
             SupportedCone::GenPowerCone(sc) => Some(SparseExpansionCone::GenPowerCone(sc)),

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
@@ -198,7 +198,11 @@ where
         // NB: faer solves in place.  Permute b to match the ordering used internally
         permute(&mut self.bperm, b, &self.perm);
 
-        let rhs = faer::mat::from_column_major_slice_mut::<T>(&mut self.bperm[0..], b.len(), 1);
+        let rhs = faer::mat::from_column_major_slice_mut::<T, usize, usize>(
+            &mut self.bperm[0..],
+            b.len(),
+            1,
+        );
         let ldlt = LdltRef::new(&self.symbolic_cholesky, self.ld_vals.as_slice());
 
         ldlt.solve_in_place_with_conj(


### PR DESCRIPTION
Increase version of faer to 0.20.   This makes rustc v1.81 the MSRV when compiling with `faer-sparse`.

Note that v1.83 actually seems to be required since the `pulp` dependency for `faer` implicitly requires v1.83.