### PR TITLE
Allow python to build with non-scipy blas and lapack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,11 @@ sdp-r          = ["sdp", "blas-src/r", "lapack-src/r"]
 julia = ["sdp", "dep:libc", "dep:num-derive",  "serde", "faer-sparse"] 
  
 # build as the python interface via maturin.
-# NB: python builds use scipy shared libraries
-# for blas/lapack, and should *not* explicitly 
-# enable a blas/lapack source package 
+# python builds will default to use scipy shared libraries
+# for blas/lapack if none of the options above are specified.
+# This is the behaviour used when building the python wheels
+# for distribution on pypi
+
 python = ["sdp", "dep:libc", "dep:pyo3", "dep:num-derive", "serde", "faer-sparse"]
 
 #compile with faer supernodal solver option

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+macro_rules! printinfo {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning=\r\x1b[36;1m   {}", format!($($tokens)*))
+    }
+}
+
+fn main() {
+    config_python_blas();
+}
+
+fn config_python_blas() {
+    // cfg(sdp_pyblas) is used to indicate that BLAS/LAPACK functions
+    // should be taken from Python's scipy.  It will only be defined
+    // for python builds that do not link to one of the blas/lapack
+    // libraries provided by blas-src and lapack-src.
+    println!("cargo:rustc-check-cfg=cfg(sdp_pyblas)");
+
+    if cfg!(not(feature = "python")) {
+        return;
+    }
+
+    if !cfg!(any(
+        feature = "sdp-accelerate",
+        feature = "sdp-netlib",
+        feature = "sdp-openblas",
+        feature = "sdp-mkl",
+        feature = "sdp-r"
+    )) {
+        printinfo!("Python: compiling with python blas from scipy");
+    } else {
+        printinfo!("Python: compiling with local blas/lapack libraries");
+    }
+}

--- a/src/algebra/dense/blas/traits.rs
+++ b/src/algebra/dense/blas/traits.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 
 cfg_if::cfg_if! {
-    if #[cfg(feature="python")] {   
+    if #[cfg(sdp_pyblas)] {
         // imports via scipy 
         use crate::python::pyblas::*;
     }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13,6 +13,11 @@ mod cscmatrix_py;
 mod impl_default_py;
 pub(crate) mod io;
 mod module_py;
+
+// compile this module if no local blas/lapack library
+// has been specified, and we want to use the python/scipy
+// version instead.  sdp_pyblas is defined in build.rs
+#[cfg(sdp_pyblas)]
 pub(crate) mod pyblas;
 
 // NB : Nothing is actually public here, but the python module itself

--- a/src/python/module_py.rs
+++ b/src/python/module_py.rs
@@ -4,6 +4,8 @@ use pyo3::prelude::*;
 #[pyfunction(name = "force_load_blas_lapack")]
 fn force_load_blas_lapack_py() {
     //force BLAS/LAPACK fcn pointer load
+    //when using scipy lapack/blas
+    #[cfg(sdp_pyblas)]
     crate::python::pyblas::force_load();
 }
 


### PR DESCRIPTION
This allows the solver to be compiled for python *without* using blas/lapack functions from scipy.   Specifying one of the supported blas/lapack features (e.g. `sdp-mkl`, `sdp-accelerate') will now use those instead, following the behaviour of non-python builds.

If the `python` feature is specified without naming a blas distribution, then the previous behaviour of acquiring blas/lapack pointers from scipy is maintained.   This is the preferred method in particular for distribution on pypi.

Note that the python interface should still be built via `maturin`.    

For the standard build with the clarabel using scipy blas / lapack:
```maturin develop --release```

To build the python interface using a local blas/lapack distribution (e.g. mkl):
``` maturin develop --release --features python,sdp-mkl```  