### PR TITLE
Update to latest blas and lapack src crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,11 @@ version = "0.19.0"
 optional = true
 
 [dependencies.blas-src]
-version = "0.10"
+version = "0.11.1"
 optional = true 
 
 [dependencies.lapack-src]
-version = "0.10"
+version = "0.11.0"
 optional = true 
 
 [dependencies.intel-mkl-src]


### PR DESCRIPTION
This updates `blas-src` and `lapack-src` to the latest versions, needed for the R package.