### PR TITLE
Adds "auto" option for ldlsolver selection

### DIFF
--- a/python/clarabel/tests/test_json.py
+++ b/python/clarabel/tests/test_json.py
@@ -1,10 +1,14 @@
-import clarabel
+import clarabel, os
 
 
 def test_json_solve():
 
+    datafile = "hs35.json"
+
     # load and solve with settings in file
-    file = "../../examples/data/hs35.json"
+    datadir = os.path.join(os.path.dirname(__file__), "../../../examples/data/")
+    file = os.path.join(datadir, datafile)
+
     solver = clarabel.load_from_file(file)
     solution = solver.solve()
     assert solution.status == clarabel.SolverStatus.Solved

--- a/python/clarabel/tests/test_json.py
+++ b/python/clarabel/tests/test_json.py
@@ -1,4 +1,5 @@
-import clarabel, os
+import clarabel
+import os
 
 
 def test_json_solve():
@@ -6,7 +7,8 @@ def test_json_solve():
     datafile = "hs35.json"
 
     # load and solve with settings in file
-    datadir = os.path.join(os.path.dirname(__file__), "../../../examples/data/")
+    thisdir = os.path.dirname(__file__)
+    datadir = os.path.join(thisdir, "../../../examples/data/")
     file = os.path.join(datadir, datafile)
 
     solver = clarabel.load_from_file(file)

--- a/src/julia/ClarabelRs/src/interface.jl
+++ b/src/julia/ClarabelRs/src/interface.jl
@@ -28,8 +28,8 @@ end
 
 function get_info(solver::Solver)
 
-    info = solver_get_info_jlrs(solver::Solver)
-    return info
+    info_jlrs = solver_get_info_jlrs(solver)
+    DefaultInfo(info_jlrs)
 
 end
 
@@ -105,7 +105,7 @@ end
 
 function solver_get_info_jlrs(solver::Solver)
 
-    ccall(Libdl.dlsym(librust,:solver_get_info_jlrs),Clarabel.DefaultInfo{Float64},
+    ccall(Libdl.dlsym(librust,:solver_get_info_jlrs),DefaultInfoJLRS,
         (Ptr{Cvoid},), solver.ptr)
 
 end

--- a/src/julia/ClarabelRs/src/types.jl
+++ b/src/julia/ClarabelRs/src/types.jl
@@ -1,6 +1,8 @@
 # The types defined here are for exchanging data
 # between Rust and Julia.   
 
+using Clarabel
+
 struct VectorJLRS{T} 
 
     p::Ptr{T}
@@ -88,7 +90,85 @@ function DefaultSolution(sol::SolutionJLRS)
         sol.r_prim,
         sol.r_dual
     )
+end
 
+struct LinearSolverInfoJLRS
+    name::VectorJLRS{UInt8}
+    threads::UInt64
+    direct::Bool
+    nnzA::UInt64 
+    nnzL::UInt64 
+end
+
+function LinearSolverInfo(info::LinearSolverInfoJLRS)
+
+    Clarabel.LinearSolverInfo(
+        Symbol(String(Vector(info.name))),
+        info.threads,
+        info.direct,
+        info.nnzA,
+        info.nnzL
+    )
+end
+
+
+mutable struct DefaultInfoJLRS
+
+    μ::Float64
+    sigma::Float64
+    step_length::Float64
+    iterations::UInt32
+    cost_primal::Float64
+    cost_dual::Float64
+    res_primal::Float64
+    res_dual::Float64
+    res_primal_inf::Float64
+    res_dual_inf::Float64
+    gap_abs::Float64
+    gap_rel::Float64
+    ktratio::Float64
+
+    # previous iterate
+    prev_cost_primal::Float64
+    prev_cost_dual::Float64
+    prev_res_primal::Float64
+    prev_res_dual::Float64
+    prev_gap_abs::Float64
+    prev_gap_rel::Float64
+
+    solve_time::Float64
+    status::Clarabel.SolverStatus
+
+    # linear solver information
+    linsolver::LinearSolverInfoJLRS
+
+end
+
+function DefaultInfo(info::DefaultInfoJLRS)
+    Clarabel.DefaultInfo{Float64}(
+        info.μ,
+        info.sigma,
+        info.step_length,
+        info.iterations,
+        info.cost_primal,
+        info.cost_dual,
+        info.res_primal,
+        info.res_dual,
+        info.res_primal_inf,
+        info.res_dual_inf,
+        info.gap_abs,
+        info.gap_rel,
+        info.ktratio,
+        info.prev_cost_primal,
+        info.prev_cost_dual,
+        info.prev_res_primal,
+        info.prev_res_dual,
+        info.prev_gap_abs,
+        info.prev_gap_rel,
+        info.solve_time,
+        info.status,
+        LinearSolverInfo(info.linsolver)
+    )
 end
 
 

--- a/src/julia/types.rs
+++ b/src/julia/types.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::algebra::CscMatrix;
+use crate::solver::core::kktsolvers::LinearSolverInfo;
 use crate::solver::implementations::default::*;
 use num_derive::FromPrimitive;
 use std::slice;
@@ -136,6 +137,28 @@ impl From<&DefaultSolution<f64>> for SolutionJLRS {
 
 #[repr(C)]
 #[derive(Debug)]
+pub struct LinearSolverInfoJLRS {
+    pub name: VectorJLRS<u8>,
+    pub threads: usize,
+    pub direct: bool,
+    pub nnzA: usize,
+    pub nnzL: usize,
+}
+
+impl From<&LinearSolverInfo> for LinearSolverInfoJLRS {
+    fn from(sol: &LinearSolverInfo) -> Self {
+        LinearSolverInfoJLRS {
+            name: VectorJLRS::<u8>::from(&sol.name.as_bytes().to_vec()),
+            threads: sol.threads,
+            direct: sol.direct,
+            nnzA: sol.nnzA,
+            nnzL: sol.nnzL,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub(crate) struct InfoJLRS {
     pub μ: f64,
     pub sigma: f64,
@@ -158,7 +181,8 @@ pub(crate) struct InfoJLRS {
     pub prev_gap_rel: f64,
     pub solve_time: f64,
     pub status: u32, //0 indexed enum in RS/JL
-                     //NB : print stream left out because it is not FFI safe
+    //NB : print stream left out because it is not FFI safe
+    pub linsolver: LinearSolverInfoJLRS,
 }
 
 impl From<&DefaultInfo<f64>> for InfoJLRS {
@@ -185,6 +209,7 @@ impl From<&DefaultInfo<f64>> for InfoJLRS {
             prev_gap_rel: sol.prev_gap_rel,
             solve_time: sol.solve_time,
             status: sol.status as u32,
+            linsolver: LinearSolverInfoJLRS::from(&sol.linsolver),
         }
     }
 }

--- a/src/julia/types.rs
+++ b/src/julia/types.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::algebra::CscMatrix;
-use crate::solver::{implementations::default::*, SolverStatus};
+use crate::solver::implementations::default::*;
 use num_derive::FromPrimitive;
 use std::slice;
 

--- a/src/python/module_py.rs
+++ b/src/python/module_py.rs
@@ -62,6 +62,8 @@ fn clarabel(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PySolverStatus>()?;
     m.add_class::<PyDefaultSolution>()?;
     m.add_class::<PyDefaultSettings>()?;
+    m.add_class::<PyDefaultInfo>()?;
+    m.add_class::<PyLinearSolverInfo>()?;
 
     // Main solver object
     m.add_class::<PyDefaultSolver>()?;

--- a/src/qdldl/qdldl.rs
+++ b/src/qdldl/qdldl.rs
@@ -234,7 +234,7 @@ fn _qdldl_new<T: FloatT>(
         iperm = _invperm(&_perm)?;
         perm = _perm;
     } else {
-        (perm, iperm) = get_amd_ordering(Ain, opts.amd_dense_scale);
+        (perm, iperm, _) = get_amd_ordering(Ain, opts.amd_dense_scale);
     }
 
     //permute to (another) upper triangular matrix and store the
@@ -895,15 +895,15 @@ fn _permute_symmetric_inner<T: FloatT>(
 pub(crate) fn get_amd_ordering<T: FloatT>(
     A: &CscMatrix<T>,
     amd_dense_scale: f64,
-) -> (Vec<usize>, Vec<usize>) {
+) -> (Vec<usize>, Vec<usize>, amd::Info) {
     // PJG: For interested readers - setting amd_dense_scale to 1.5 seems to work better
     // for KKT systems in QP problems, but this ad hoc method can surely be improved
 
     // computes a permutation for A using AMD default parameters
     let mut control = amd::Control::default();
     control.dense *= amd_dense_scale; //increase the default value
-    let (perm, iperm, _info) = amd::order(A.nrows(), &A.colptr, &A.rowval, &control).unwrap();
-    (perm, iperm)
+    let (perm, iperm, info) = amd::order(A.nrows(), &A.colptr, &A.rowval, &control).unwrap();
+    (perm, iperm, info)
 }
 
 //configure tests of internals

--- a/src/qdldl/qdldl.rs
+++ b/src/qdldl/qdldl.rs
@@ -198,6 +198,16 @@ where
             self.is_symbolic,
         )
     }
+
+    /// Returns the number of nonzeros in A for A = LDL^T
+    pub fn nnzA(&self) -> usize {
+        self.workspace.triuA.nnz()
+    }
+
+    /// Returns the number of nonzeros in L for A = LDL^T
+    pub fn nnzL(&self) -> usize {
+        self.L.nnz()
+    }
 }
 
 fn check_structure<T: FloatT>(A: &CscMatrix<T>) -> Result<(), QDLDLError> {

--- a/src/qdldl/qdldl.rs
+++ b/src/qdldl/qdldl.rs
@@ -33,7 +33,7 @@ pub struct QDLDLSettings<T: FloatT> {
     #[builder(default = "1.0")]
     pub amd_dense_scale: f64,
 
-    /// optional ueser-supplied custom permutation vector for the matrix
+    /// optional user-supplied custom permutation vector for the matrix
     #[builder(default = "None", setter(strip_option))]
     pub perm: Option<Vec<usize>>,
 

--- a/src/qdldl/test.rs
+++ b/src/qdldl/test.rs
@@ -123,7 +123,7 @@ fn test_etree() {
 #[test]
 fn test_amd() {
     let A = test_matrix_4x4();
-    let (perm, iperm) = get_amd_ordering(&A, 1.5);
+    let (perm, iperm, _) = get_amd_ordering(&A, 1.5);
     assert_eq!(perm, [3, 0, 1, 2]);
     assert_eq!(iperm, [1, 2, 3, 0]);
 }

--- a/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
@@ -5,7 +5,7 @@ use super::ldlsolvers::faer_ldl::*;
 
 use super::ldlsolvers::{auto::*, qdldl::*};
 use super::*;
-use crate::solver::core::kktsolvers::KKTSolver;
+use crate::solver::core::kktsolvers::{HasLinearSolverInfo, KKTSolver, LinearSolverInfo};
 use crate::solver::core::{cones::*, CoreSettings};
 use std::iter::zip;
 
@@ -114,6 +114,15 @@ where
             ldlsolver,
             diagonal_regularizer,
         }
+    }
+}
+
+impl<T> HasLinearSolverInfo for DirectLDLKKTSolver<T>
+where
+    T: FloatT,
+{
+    fn linear_solver_info(&self) -> LinearSolverInfo {
+        self.ldlsolver.linear_solver_info()
     }
 }
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/auto.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/auto.rs
@@ -1,0 +1,84 @@
+#![allow(non_snake_case)]
+use crate::algebra::*;
+use crate::solver::core::kktsolvers::direct::ldlsolvers::qdldl::QDLDLDirectLDLSolver;
+use crate::solver::core::kktsolvers::direct::BoxedDirectLDLSolver;
+use crate::solver::core::kktsolvers::direct::DirectLDLSolverReqs;
+use crate::solver::core::CoreSettings;
+
+pub struct AutoDirectLDLSolver<T> {
+    T: std::marker::PhantomData<T>,
+}
+
+impl<T> DirectLDLSolverReqs<T> for AutoDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    fn required_matrix_shape() -> MatrixTriangle {
+        MatrixTriangle::Triu
+    }
+}
+
+impl<T> AutoDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        KKT: &CscMatrix<T>,
+        Dsigns: &[i8],
+        settings: &CoreSettings<T>,
+    ) -> BoxedDirectLDLSolver<T> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "faer-sparse")] {
+                ldl_auto_select(KKT, Dsigns, settings)
+            } else {
+                let solver = QDLDLDirectLDLSolver::<T>::new(KKT, Dsigns, settings);
+                Box::new(solver)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "faer-sparse")]
+fn ldl_auto_select<T>(
+    KKT: &CscMatrix<T>,
+    Dsigns: &[i8],
+    settings: &CoreSettings<T>,
+) -> BoxedDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    use crate::solver::core::kktsolvers::direct::ldlsolvers::faer_ldl::FaerDirectLDLSolver;
+
+    assert!(KKT.is_square(), "KKT matrix is not square");
+
+    // Compute an AMD ordering for the KKT matrix,
+    // and use it to determine whether we want to
+    // use the QDLDL solver or the faer.  Slight
+    // inefficiency here because we will end up computing
+    // the AMD ordering twice.   Switch rule is the same
+    // as the one internal to faer.   Done this way because
+    // QDLDL appears to be faster than faer's simplicial method.
+
+    // manually compute an AMD ordering for the KKT matrix
+    let amd_dense_scale = 1.5; // magic number from QDLDL
+    let (_perm, _iperm, info) = crate::qdldl::get_amd_ordering(KKT, amd_dense_scale);
+
+    // estimate flops and then use the faer switching rule
+    let flops = (info.n_div + info.n_mult_subs_ldl) as f64;
+    let Lnnz = info.lnz as f64;
+
+    // threshold for switching to QDLDL
+    // let thresh = faer::sparse::linalg::CHOLESKY_SUPERNODAL_RATIO_FACTOR;
+    let thresh = 40.0;
+
+    if (flops / Lnnz) < thresh {
+        // use QDLDL
+        let solver = QDLDLDirectLDLSolver::<T>::new(KKT, Dsigns, settings);
+        Box::new(solver)
+    } else {
+        // use faer
+        let solver = FaerDirectLDLSolver::<T>::new(KKT, Dsigns, settings);
+        Box::new(solver)
+    }
+}

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
@@ -27,7 +27,7 @@ use faer::{
 };
 
 use crate::algebra::*;
-use crate::solver::core::kktsolvers::direct::DirectLDLSolver;
+use crate::solver::core::kktsolvers::direct::{DirectLDLSolver, DirectLDLSolverReqs};
 use crate::solver::core::CoreSettings;
 use std::iter::zip;
 
@@ -109,7 +109,7 @@ where
         // manually compute an AMD ordering for the KKT matrix
         // and permute it to match the ordering used in QDLDL
         let amd_dense_scale = 1.5; // magic number from QDLDL
-        let (perm, iperm) = crate::qdldl::get_amd_ordering(KKT, amd_dense_scale);
+        let (perm, iperm, _) = crate::qdldl::get_amd_ordering(KKT, amd_dense_scale);
 
         let (mut perm_kkt, mut perm_map) = crate::qdldl::permute_symmetric(KKT, &iperm);
 
@@ -184,6 +184,15 @@ where
             work,
             parallelism,
         }
+    }
+}
+
+impl<T> DirectLDLSolverReqs<T> for FaerDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    fn required_matrix_shape() -> MatrixTriangle {
+        MatrixTriangle::Triu
     }
 }
 
@@ -265,10 +274,6 @@ where
                 self.ldlt_params,
             )
             .is_ok() // PJG: convert to bool for consistency with qdldl.   Should really return Result here and elsewhere
-    }
-
-    fn required_matrix_shape() -> MatrixTriangle {
-        MatrixTriangle::Triu
     }
 }
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
@@ -1,15 +1,7 @@
 #![allow(non_snake_case)]
 
 use faer::dyn_stack::{MemBuffer, MemStack, StackReq};
-// use faer::{
-//     dyn_stack::{GlobalPodBuffer, PodStack, StackReq},
-//     linalg::cholesky::ldlt::compute::LdltRegularization,
-//     sparse::{
-//         linalg::{amd::Control, cholesky::*, SupernodalThreshold},
-//         SparseColMatRef, SymbolicSparseColMatRef,
-//     },
-//     Conj, Parallelism, Side,
-// };
+
 use faer::{
     linalg::cholesky::ldlt::factor::{LdltParams, LdltRegularization},
     sparse::{
@@ -92,7 +84,12 @@ where
         faer::utils::thread::parallelism_degree(faer::Par::rayon(setting))
     }
 
-    pub fn new(KKT: &CscMatrix<T>, Dsigns: &[i8], settings: &CoreSettings<T>) -> Self {
+    pub fn new(
+        KKT: &CscMatrix<T>,
+        Dsigns: &[i8],
+        settings: &CoreSettings<T>,
+        perm: Option<Vec<usize>>,
+    ) -> Self {
         assert!(KKT.is_square(), "KKT matrix is not square");
 
         // -----------------------------
@@ -106,10 +103,17 @@ where
             }
         };
 
-        // manually compute an AMD ordering for the KKT matrix
-        // and permute it to match the ordering used in QDLDL
-        let amd_dense_scale = 1.5; // magic number from QDLDL
-        let (perm, iperm, _) = crate::qdldl::get_amd_ordering(KKT, amd_dense_scale);
+        // perm has possibly been passed by LDL auto selector.
+        // If not, find an ordering now
+        let (perm, iperm) = {
+            if let Some(perm) = perm {
+                let iperm = invperm(&perm);
+                (perm, iperm)
+            } else {
+                let (perm, iperm, _) = super::amd_order(KKT);
+                (perm, iperm)
+            }
+        };
 
         let (mut perm_kkt, mut perm_map) = crate::qdldl::permute_symmetric(KKT, &iperm);
 
@@ -341,7 +345,7 @@ fn test_faer_ldl() {
 
     let Dsigns = vec![1, 1, -1, -1, -1, -1];
 
-    let mut solver = FaerDirectLDLSolver::new(&KKT, &Dsigns, &CoreSettings::default());
+    let mut solver = FaerDirectLDLSolver::new(&KKT, &Dsigns, &CoreSettings::default(), None);
 
     let mut x = vec![0.0; 6];
     let b = vec![1.0, 2.0, 3.0, 4., 5., 6.];

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
@@ -20,6 +20,7 @@ use faer::{
 
 use crate::algebra::*;
 use crate::solver::core::kktsolvers::direct::{DirectLDLSolver, DirectLDLSolverReqs};
+use crate::solver::core::kktsolvers::{HasLinearSolverInfo, LinearSolverInfo};
 use crate::solver::core::CoreSettings;
 use std::iter::zip;
 
@@ -80,10 +81,6 @@ impl<T> FaerDirectLDLSolver<T>
 where
     T: FloatT,
 {
-    pub fn nthreads_from_settings(setting: usize) -> usize {
-        faer::utils::thread::parallelism_degree(faer::Par::rayon(setting))
-    }
-
     pub fn new(
         KKT: &CscMatrix<T>,
         Dsigns: &[i8],
@@ -197,6 +194,21 @@ where
 {
     fn required_matrix_shape() -> MatrixTriangle {
         MatrixTriangle::Triu
+    }
+}
+
+impl<T> HasLinearSolverInfo for FaerDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    fn linear_solver_info(&self) -> LinearSolverInfo {
+        LinearSolverInfo {
+            name: "faer".to_string(),
+            threads: self.parallelism.degree(),
+            direct: true,
+            nnzA: self.perm_kkt.nnz(),
+            nnzL: self.ld_vals.len() - self.perm_kkt.n,
+        }
     }
 }
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
@@ -7,6 +7,7 @@ pub mod faer_ldl;
 pub mod auto;
 pub mod qdldl;
 
+#[allow(dead_code)]
 pub(crate) fn amd_order<T>(KKT: &CscMatrix<T>) -> (Vec<usize>, Vec<usize>, Info)
 where
     T: FloatT,

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
@@ -1,5 +1,18 @@
+use crate::algebra::{CscMatrix, FloatT};
+use amd::Info;
+
 #[cfg(feature = "faer-sparse")]
 pub mod faer_ldl;
 
 pub mod auto;
 pub mod qdldl;
+
+pub(crate) fn amd_order<T>(KKT: &CscMatrix<T>) -> (Vec<usize>, Vec<usize>, Info)
+where
+    T: FloatT,
+{
+    // manually compute an AMD ordering for the KKT matrix
+    let amd_dense_scale = 1.5; // magic number from QDLDL
+    let (perm, iperm, info) = crate::qdldl::get_amd_ordering(KKT, amd_dense_scale);
+    (perm, iperm, info)
+}

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/mod.rs
@@ -1,3 +1,5 @@
 #[cfg(feature = "faer-sparse")]
 pub mod faer_ldl;
+
+pub mod auto;
 pub mod qdldl;

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
@@ -13,7 +13,12 @@ impl<T> QDLDLDirectLDLSolver<T>
 where
     T: FloatT,
 {
-    pub fn new(KKT: &CscMatrix<T>, Dsigns: &[i8], settings: &CoreSettings<T>) -> Self {
+    pub fn new(
+        KKT: &CscMatrix<T>,
+        Dsigns: &[i8],
+        settings: &CoreSettings<T>,
+        perm: Option<Vec<usize>>,
+    ) -> Self {
         assert!(KKT.is_square(), "KKT matrix is not square");
 
         // occasionally we find that the default AMD parameters give a bad ordering, particularly
@@ -25,7 +30,7 @@ where
 
         //make a logical factorization to determine memory allocations
 
-        let opts = QDLDLSettingsBuilder::default()
+        let mut opts = QDLDLSettingsBuilder::default()
             .logical(true) //allocate memory only on init
             .Dsigns(Dsigns.to_vec())
             .regularize_enable(true)
@@ -34,6 +39,7 @@ where
             .amd_dense_scale(1.5)
             .build()
             .unwrap();
+        opts.perm = perm;
 
         let factors = QDLDLFactorisation::<T>::new(KKT, Some(opts)).unwrap();
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
@@ -2,6 +2,8 @@
 use crate::algebra::*;
 use crate::qdldl::*;
 use crate::solver::core::kktsolvers::direct::{DirectLDLSolver, DirectLDLSolverReqs};
+use crate::solver::core::kktsolvers::HasLinearSolverInfo;
+use crate::solver::core::kktsolvers::LinearSolverInfo;
 use crate::solver::core::CoreSettings;
 
 pub struct QDLDLDirectLDLSolver<T> {
@@ -53,6 +55,21 @@ where
 {
     fn required_matrix_shape() -> MatrixTriangle {
         MatrixTriangle::Triu
+    }
+}
+
+impl<T> HasLinearSolverInfo for QDLDLDirectLDLSolver<T>
+where
+    T: FloatT,
+{
+    fn linear_solver_info(&self) -> LinearSolverInfo {
+        LinearSolverInfo {
+            name: "qdldl".to_string(),
+            threads: 1,
+            direct: true,
+            nnzA: self.factors.nnzA(),
+            nnzL: self.factors.nnzL(),
+        }
     }
 }
 

--- a/src/solver/core/kktsolvers/direct/quasidef/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/mod.rs
@@ -1,4 +1,4 @@
-use crate::algebra::*;
+use crate::{algebra::*, solver::core::kktsolvers::HasLinearSolverInfo};
 
 //ldl linear solvers kept in a submodule (not flattened)
 pub mod ldlsolvers;
@@ -16,7 +16,7 @@ pub trait DirectLDLSolverReqs<T: FloatT> {
     where
         Self: Sized;
 }
-pub trait DirectLDLSolver<T: FloatT>: DirectLDLSolverReqs<T> {
+pub trait DirectLDLSolver<T: FloatT>: DirectLDLSolverReqs<T> + HasLinearSolverInfo {
     fn update_values(&mut self, index: &[usize], values: &[T]);
     fn scale_values(&mut self, index: &[usize], scale: T);
     #[allow(dead_code)] //PJG: could be removed.

--- a/src/solver/core/kktsolvers/direct/quasidef/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/mod.rs
@@ -11,14 +11,16 @@ use datamaps::*;
 pub use directldlkktsolver::*;
 use kkt_assembly::*;
 
-pub trait DirectLDLSolver<T: FloatT> {
+pub trait DirectLDLSolverReqs<T: FloatT> {
+    fn required_matrix_shape() -> MatrixTriangle
+    where
+        Self: Sized;
+}
+pub trait DirectLDLSolver<T: FloatT>: DirectLDLSolverReqs<T> {
     fn update_values(&mut self, index: &[usize], values: &[T]);
     fn scale_values(&mut self, index: &[usize], scale: T);
     #[allow(dead_code)] //PJG: could be removed.
     fn offset_values(&mut self, index: &[usize], offset: T, signs: &[i8]);
     fn solve(&mut self, kkt: &CscMatrix<T>, x: &mut [T], b: &[T]);
     fn refactor(&mut self, kkt: &CscMatrix<T>) -> bool;
-    fn required_matrix_shape() -> MatrixTriangle
-    where
-        Self: Sized;
 }

--- a/src/solver/core/kktsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/mod.rs
@@ -20,11 +20,12 @@ pub trait KKTSolver<T: FloatT>: HasLinearSolverInfo {
 pub trait HasLinearSolverInfo {
     fn linear_solver_info(&self) -> LinearSolverInfo;
 }
+#[repr(C)]
 #[derive(Debug, Default, Clone)]
 pub struct LinearSolverInfo {
     pub name: String,
     pub threads: usize,
     pub direct: bool,
-    pub nnzA: usize, // nnz in A = LDL^T
-    pub nnzL: usize, // nnz in P = LDL^T
+    pub nnzA: usize, // nnz in A for A = LDL^T
+    pub nnzL: usize, // nnz in L for A = LDL^T
 }

--- a/src/solver/core/kktsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/mod.rs
@@ -22,10 +22,17 @@ pub trait HasLinearSolverInfo {
 }
 #[repr(C)]
 #[derive(Debug, Default, Clone)]
+/// Linear subsolver information.
+///
 pub struct LinearSolverInfo {
+    /// Name of the linear solver that was used
     pub name: String,
+    /// Number of threads used by solver
     pub threads: usize,
+    /// Whether the solver used a direct factorisation method
     pub direct: bool,
+    /// Number of nonzeros in the linear system
     pub nnzA: usize, // nnz in A for A = LDL^T
+    /// Number of nonzeros in the factored system
     pub nnzL: usize, // nnz in L for A = LDL^T
 }

--- a/src/solver/core/kktsolvers/mod.rs
+++ b/src/solver/core/kktsolvers/mod.rs
@@ -4,7 +4,7 @@ use crate::algebra::*;
 
 pub mod direct;
 
-pub trait KKTSolver<T: FloatT> {
+pub trait KKTSolver<T: FloatT>: HasLinearSolverInfo {
     fn update(&mut self, cones: &CompositeCone<T>, settings: &CoreSettings<T>) -> bool;
     fn setrhs(&mut self, x: &[T], z: &[T]);
     fn solve(
@@ -15,4 +15,16 @@ pub trait KKTSolver<T: FloatT> {
     ) -> bool;
     fn update_P(&mut self, P: &CscMatrix<T>);
     fn update_A(&mut self, A: &CscMatrix<T>);
+}
+
+pub trait HasLinearSolverInfo {
+    fn linear_solver_info(&self) -> LinearSolverInfo;
+}
+#[derive(Debug, Default, Clone)]
+pub struct LinearSolverInfo {
+    pub name: String,
+    pub threads: usize,
+    pub direct: bool,
+    pub nnzA: usize, // nnz in A = LDL^T
+    pub nnzL: usize, // nnz in P = LDL^T
 }

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::algebra::*;
 use crate::io::PrintTarget;
+use crate::solver::core::kktsolvers::LinearSolverInfo;
 use crate::solver::core::{traits::Info, SolverStatus};
 use crate::solver::traits::Variables;
 use crate::timers::*;
@@ -53,6 +54,9 @@ pub struct DefaultInfo<T> {
     pub solve_time: f64,
     /// solver status
     pub status: SolverStatus,
+
+    /// linear solver information
+    pub linsolver: LinearSolverInfo,
 
     // target stream for printing
     pub(crate) stream: PrintTarget,

--- a/src/solver/implementations/default/kktsystem.rs
+++ b/src/solver/implementations/default/kktsystem.rs
@@ -87,6 +87,15 @@ where
     }
 }
 
+impl<T> HasLinearSolverInfo for DefaultKKTSystem<T>
+where
+    T: FloatT,
+{
+    fn linear_solver_info(&self) -> LinearSolverInfo {
+        self.kktsolver.linear_solver_info()
+    }
+}
+
 impl<T> KKTSystem<T> for DefaultKKTSystem<T>
 where
     T: FloatT,

--- a/src/solver/implementations/default/settings.rs
+++ b/src/solver/implementations/default/settings.rs
@@ -118,8 +118,8 @@ pub struct DefaultSettings<T: FloatT> {
     #[builder(default = "true")]
     pub direct_kkt_solver: bool,
 
-    ///direct linear solver (e.g. "qdldl")
-    #[builder(default = r#""qdldl".to_string()"#)]
+    ///direct linear solver method(e.g. "faer-sparse", "qdldl", "auto")
+    #[builder(default = r#""auto".to_string()"#)]
     pub direct_solve_method: String,
 
     ///enable KKT static regularization
@@ -270,6 +270,7 @@ where
 
 fn validate_direct_solve_method(direct_solve_method: &str) -> Result<(), String> {
     match direct_solve_method {
+        "auto" => Ok(()),
         "qdldl" => Ok(()),
         #[cfg(feature = "faer-sparse")]
         "faer" => Ok(()),

--- a/src/solver/implementations/default/solver.rs
+++ b/src/solver/implementations/default/solver.rs
@@ -3,6 +3,7 @@ use crate::{
     io::ConfigurablePrintTarget,
     solver::core::{
         cones::{CompositeCone, SupportedConeT},
+        kktsolvers::HasLinearSolverInfo,
         traits::ProblemData,
         Solver,
     },
@@ -40,7 +41,7 @@ where
 
         let mut timers = Timers::default();
         let mut output;
-        let info = DefaultInfo::<T>::new();
+        let mut info = DefaultInfo::<T>::new();
 
         timeit! {timers => "setup"; {
 
@@ -70,6 +71,7 @@ where
         timeit!{timers => "kktinit"; {
             kktsystem = DefaultKKTSystem::<T>::new(&data,&cones,&settings);
         }}
+        info.linsolver = kktsystem.linear_solver_info();
 
         // work variables for assembling step direction LHS/RHS
         let step_rhs  = DefaultVariables::<T>::new(data.n,data.m);

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -28,6 +28,7 @@ pub use crate::solver::core::cones::{SupportedConeT, SupportedConeT::*};
 
 //user facing traits required to interact with solver
 pub use crate::solver::core::{IPSolver, SolverStatus};
+pub use crate::solver::core::kktsolvers::LinearSolverInfo;
 
 //user facing traits required to define new implementatiions
 pub use crate::solver::core::traits;


### PR DESCRIPTION
When built with `faer-sparse`, choosing :auto as the ldlsolver type (now the default), will choose :qdldl when simplicial factorisation seems faster, and :faer if supernodal seems faster.

Implemented this way because qdldl is still a bit faster in the simplicial case.

Adds a `LinearSolverInfo` struct to the information output with some factorisation detail.