### PR TITLE
structural dropzeros in P/A

### DIFF
--- a/examples/rust/example_json.rs
+++ b/examples/rust/example_json.rs
@@ -1,13 +1,22 @@
 #![allow(non_snake_case)]
 use clarabel::solver::*;
+use std::env;
 use std::fs::File;
+use std::path::PathBuf;
 
 fn main() {
     // HS35 is a small problem QP problem
     // from the Maros-Meszaros test set
+    let filename = "hs35.json";
 
-    let filename = "./examples/data/hs35.json";
-    let mut file = File::open(filename).unwrap();
+    // Get the path to the crate root using the CARGO_MANIFEST_DIR environment variable
+    let cargo_dir = env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
+    let data_path = PathBuf::from(cargo_dir).join("examples").join("data");
+
+    // now I have the path to the file
+    let filename = data_path.join(filename);
+    let mut file = File::open(&filename).unwrap();
+
     let mut solver = DefaultSolver::<f64>::load_from_file(&mut file, None).unwrap();
     solver.solve();
 

--- a/src/algebra/csc/core.rs
+++ b/src/algebra/csc/core.rs
@@ -263,7 +263,7 @@ where
             self.colptr[col + 1] = writeidx;
         }
 
-        let dropcount = writeidx - self.nzval.len();
+        let dropcount = self.nzval.len() - writeidx;
 
         self.rowval.resize(writeidx, 0);
         self.nzval.resize(writeidx, T::zero());

--- a/src/python/impl_default_py.rs
+++ b/src/python/impl_default_py.rs
@@ -432,6 +432,9 @@ pub struct PyDefaultSettings {
     #[pyo3(get, set)]
     pub presolve_enable: bool,
 
+    #[pyo3(get, set)]
+    pub input_sparse_dropzeros: bool,
+
     //chordal decomposition (python must be built with "sdp" feature)
     #[pyo3(get, set)]
     pub chordal_decomposition_enable: bool,
@@ -511,6 +514,7 @@ impl From<&DefaultSettings<f64>> for PyDefaultSettings {
             iterative_refinement_max_iter: set.iterative_refinement_max_iter,
             iterative_refinement_stop_ratio: set.iterative_refinement_stop_ratio,
             presolve_enable: set.presolve_enable,
+            input_sparse_dropzeros: set.input_sparse_dropzeros,
             chordal_decomposition_enable: set.chordal_decomposition_enable,
             chordal_decomposition_merge_method: set.chordal_decomposition_merge_method.clone(),
             chordal_decomposition_compact: set.chordal_decomposition_compact,
@@ -562,6 +566,7 @@ impl PyDefaultSettings {
             iterative_refinement_max_iter: self.iterative_refinement_max_iter,
             iterative_refinement_stop_ratio: self.iterative_refinement_stop_ratio,
             presolve_enable: self.presolve_enable,
+            input_sparse_dropzeros: self.input_sparse_dropzeros,
             chordal_decomposition_enable: self.chordal_decomposition_enable,
             chordal_decomposition_merge_method: self.chordal_decomposition_merge_method.clone(),
             chordal_decomposition_compact: self.chordal_decomposition_compact,

--- a/src/solver/implementations/default/ffi/settings.rs
+++ b/src/solver/implementations/default/ffi/settings.rs
@@ -64,6 +64,7 @@ pub struct DefaultSettingsFFI<T: FloatT> {
 
     // preprocessing
     pub presolve_enable: bool,
+    pub input_sparse_dropzeros: bool,
 
     // chordal decomposition
     #[cfg(feature = "sdp")]
@@ -127,6 +128,7 @@ macro_rules! impl_from {
                     iterative_refinement_max_iter: settings.iterative_refinement_max_iter,
                     iterative_refinement_stop_ratio: settings.iterative_refinement_stop_ratio,
                     presolve_enable: settings.presolve_enable,
+                    input_sparse_dropzeros: settings.input_sparse_dropzeros,
                     #[cfg(feature = "sdp")]
                     chordal_decomposition_enable: settings.chordal_decomposition_enable,
                     #[cfg(feature = "sdp")]

--- a/src/solver/implementations/default/problemdata.rs
+++ b/src/solver/implementations/default/problemdata.rs
@@ -42,6 +42,7 @@ pub struct DefaultProblemData<T> {
     normb: Option<T>,
 
     pub(crate) presolver: Option<Presolver<T>>,
+    dropped_zeros: usize, // number of eliminated structural zeros
 
     #[cfg(feature = "sdp")]
     pub(crate) chordal_info: Option<ChordalInfo<T>>,
@@ -114,9 +115,9 @@ where
         // haven't made one already.   Necessary since we will scale
         // the internal copy and don't want to step on the user
 
-        let P_new = P_new.unwrap_or_else(|| P.clone());
+        let mut P_new = P_new.unwrap_or_else(|| P.clone());
         let q_new = q_new.unwrap_or_else(|| q.to_vec());
-        let A_new = A_new.unwrap_or_else(|| A.clone());
+        let mut A_new = A_new.unwrap_or_else(|| A.clone());
         let mut b_new = b_new.unwrap_or_else(|| b.to_vec());
 
         // cones was already copied, so can just pass through without cloning
@@ -131,6 +132,15 @@ where
 
         // this ensures m is the *reduced* size m
         let (m, n) = A_new.size();
+
+        // explicitly dropzeros on the copied data, since dropzeros
+        // operates in place.  PJG: revisit this order of operations
+        // once a proper presolver is implemented, since it might
+        // be preferable to dropzeros then presolve
+        let mut dropped_zeros = 0;
+        if settings.input_sparse_dropzeros {
+            dropped_zeros += P_new.dropzeros() + A_new.dropzeros();
+        }
 
         let equilibration = DefaultEquilibrationData::<T>::new(n, m);
 
@@ -148,6 +158,7 @@ where
             equilibration,
             normq,
             normb,
+            dropped_zeros,
             presolver,
             #[cfg(feature = "sdp")]
             chordal_info,
@@ -189,6 +200,12 @@ where
     //reduction or chordal decomposition
     pub(crate) fn is_presolved(&self) -> bool {
         self.presolver.is_some()
+    }
+
+    // data updating not supported if structural zeros
+    // have been eliminated
+    pub(crate) fn is_dropped_zeros(&self) -> bool {
+        self.dropped_zeros != 0
     }
 
     #[allow(dead_code)]

--- a/src/solver/implementations/default/settings.rs
+++ b/src/solver/implementations/default/settings.rs
@@ -171,6 +171,14 @@ pub struct DefaultSettings<T: FloatT> {
     #[builder(default = "true")]
     pub presolve_enable: bool,
 
+    ///explicitly drop structural zeros from sparse data inputs
+    ///Caution: this will disable parametric updating functionality
+    ///See also ['dropzeros'][crate::algebra::CscMatrix::dropzeros]
+    ///for dropping structural zeros before passing to the solver
+    ///
+    #[builder(default = "false")]
+    pub input_sparse_dropzeros: bool,
+
     /// enable chordal decomposition.
     /// [requires "sdp" feature.]
     #[cfg(feature = "sdp")]

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -35,6 +35,7 @@ fn updating_test_data() -> (
 
     let settings = DefaultSettingsBuilder::default()
         .presolve_enable(false)
+        .input_sparse_dropzeros(false)
         .equilibrate_enable(true)
         .build()
         .unwrap();


### PR DESCRIPTION
Add a setting to explicitly drop structural zeros on sparse problem inputs.

This setting defaults to `false` since dropping structural zeros disable problem data updates as a side effect.