### PR TITLE
Validation checks during during solver creation and updates

### DIFF
--- a/examples/rust/example_box.rs
+++ b/examples/rust/example_box.rs
@@ -31,7 +31,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 }

--- a/examples/rust/example_box_faer.rs
+++ b/examples/rust/example_box_faer.rs
@@ -33,7 +33,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 }

--- a/examples/rust/example_callback.rs
+++ b/examples/rust/example_callback.rs
@@ -37,7 +37,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     // setup a custom termination function
     let f = |info: &DefaultInfo<f64>| {

--- a/examples/rust/example_expcone.rs
+++ b/examples/rust/example_expcone.rs
@@ -27,6 +27,6 @@ fn main() {
         verbose: true,
         ..DefaultSettings::default()
     };
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
     solver.solve();
 }

--- a/examples/rust/example_lp.rs
+++ b/examples/rust/example_lp.rs
@@ -34,7 +34,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 }

--- a/examples/rust/example_powcone.rs
+++ b/examples/rust/example_powcone.rs
@@ -38,6 +38,6 @@ fn main() {
         max_iter: 100,
         ..DefaultSettings::default()
     };
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
     solver.solve();
 }

--- a/examples/rust/example_qp.rs
+++ b/examples/rust/example_qp.rs
@@ -49,7 +49,7 @@ fn main() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/examples/rust/example_sdp.rs
+++ b/examples/rust/example_sdp.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 }

--- a/examples/rust/example_socp.rs
+++ b/examples/rust/example_socp.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/python/clarabel/tests/test_settings.py
+++ b/python/clarabel/tests/test_settings.py
@@ -33,7 +33,7 @@ def test_settings(get_settings_qp_data):
     solver = clarabel.DefaultSolver(P, q, A, b, cones, settings)
     solver.solve()
 
-    # make and apply bad settings 
+    # make and apply bad settings
     settings = clarabel.DefaultSettings()
     settings.direct_solve_method = "foo"
     with pytest.raises(Exception) as e:
@@ -52,12 +52,3 @@ def test_settings(get_settings_qp_data):
         solver.update(settings=settings)
 
     print(e)
-
-
-
-
-
-
-
-
-

--- a/python/clarabel/tests/test_settings.py
+++ b/python/clarabel/tests/test_settings.py
@@ -1,0 +1,63 @@
+import clarabel
+import pytest
+import numpy as np
+from scipy import sparse
+
+
+@pytest.fixture
+def get_settings_qp_data():
+
+    P = sparse.csc_matrix([[4., 1.], [1., 2.]])
+    P = sparse.triu(P).tocsc()
+
+    A = sparse.csc_matrix(
+        [[-1., -1.],
+         [-1.,  0.],
+         [0.,  -1.],
+         [1.,   1.],
+         [1.,   0.],
+         [0.,   1.]])
+
+    q = np.array([1., 1.])
+    b = np.array([-1., 0., 0., 1., 0.7, 0.7])
+
+    cones = [clarabel.NonnegativeConeT(3), clarabel.NonnegativeConeT(3)]
+    return P, q, A, b, cones
+
+
+def test_settings(get_settings_qp_data):
+
+    P, q, A, b, cones = get_settings_qp_data
+    settings = clarabel.DefaultSettings()
+
+    solver = clarabel.DefaultSolver(P, q, A, b, cones, settings)
+    solver.solve()
+
+    # make and apply bad settings 
+    settings = clarabel.DefaultSettings()
+    settings.direct_solve_method = "foo"
+    with pytest.raises(Exception) as e:
+        clarabel.DefaultSolver(P, q, A, b, cones, settings)
+
+    print(e)
+
+    # make and apply good settings, then overwrite with bad ones
+    settings = clarabel.DefaultSettings()
+    settings.presolve_enable = True
+    solver = clarabel.DefaultSolver(P, q, A, b, cones, settings)
+    solver.solve()
+
+    settings.presolve_enable = False
+    with pytest.raises(Exception) as e:
+        solver.update(settings=settings)
+
+    print(e)
+
+
+
+
+
+
+
+
+

--- a/src/algebra/dense/traits.rs
+++ b/src/algebra/dense/traits.rs
@@ -10,7 +10,7 @@ pub(crate) trait FactorEigen<T> {
     where
         S: AsMut<[T]> + AsRef<[T]>;
     // computes eigenvalues and vectors (full set)
-    #[allow(dead_code)] //PJG: not currently used anywhere
+    #[allow(dead_code)] //PJG: implemented for some future projection method
     fn eigen<S>(&mut self, A: &mut DenseStorageMatrix<S, T>) -> Result<(), DenseFactorizationError>
     where
         S: AsMut<[T]> + AsRef<[T]>;

--- a/src/julia/interface.rs
+++ b/src/julia/interface.rs
@@ -69,17 +69,15 @@ pub(crate) extern "C" fn solver_new_jlrs(
     let cones = ccall_arrays_to_cones(jlcones);
     let settings = settings_from_json(json_settings);
 
-    // manually validate settings from Julia side
-    match settings.validate() {
-        Ok(_) => (),
+    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+
+    match solver {
+        Ok(solver) => to_ptr(Box::new(solver)),
         Err(e) => {
-            println!("Invalid settings: {}", e);
+            println!("Error creating solver: {}", e);
             return std::ptr::null_mut();
         }
-    };
-
-    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
-    to_ptr(Box::new(solver))
+    }
 }
 
 #[no_mangle]

--- a/src/python/impl_default_py.rs
+++ b/src/python/impl_default_py.rs
@@ -269,6 +269,12 @@ impl PyDefaultSolution {
 // Solver Status
 // ----------------------------------
 
+impl From<SolverError> for PyErr {
+    fn from(err: SolverError) -> Self {
+        PyException::new_err(err.to_string())
+    }
+}
+
 #[derive(PartialEq, Debug, Clone, Copy)]
 #[pyclass(eq, eq_int, name = "SolverStatus")]
 pub enum PySolverStatus {
@@ -627,7 +633,12 @@ impl PyDefaultSolver {
         let cones = _py_to_native_cones(cones);
         let settings = settings.to_internal()?;
 
-        let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+        // Handle the Result returned by DefaultSolver::new
+        // match DefaultSolver::new(&P, &q, &A, &b, &cones, settings) {
+        //     Ok(solver) => Ok(Self { inner: solver }),
+        //     Err(e) => Err(e.into()),
+        // }
+        let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
         Ok(Self { inner: solver })
     }
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/faer_ldl.rs
@@ -436,7 +436,7 @@ fn test_faer_qp() {
         .build()
         .unwrap();
 
-    let mut solver = crate::solver::DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = crate::solver::DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/pardiso.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/pardiso.rs
@@ -149,14 +149,6 @@ where
             ps.set_message_level(MessageLevel::Off);
         }
 
-        // PJG: catching of bad iparm parameters should instead
-        // be implemented into the settings constructor and
-        // settings validation code, so that bad parameters
-        // can be rejected or filtered without causing a panic
-
-        // check for very bad parameters here
-        assert_pardiso_const_rhs_config(ps);
-
         //perform logical factorization
         ps.set_phase(Phase::Analysis);
 
@@ -300,8 +292,6 @@ where
         ps.set_phase(Phase::SolveIterativeRefine);
         let n = b.len() as i32;
 
-        assert_pardiso_const_rhs_config(ps);
-
         ps.pardiso(nzvals, colptrs, rowvals, b, x, n, 1_i32)
             .unwrap();
     }
@@ -318,8 +308,6 @@ where
         let ps = &mut self.ps;
         ps.set_phase(Phase::NumFact);
 
-        assert_pardiso_const_rhs_config(ps);
-
         ps.pardiso(
             nzvals,
             colptrs,
@@ -333,15 +321,13 @@ where
     }
 }
 
-fn assert_pardiso_const_rhs_config<P>(ps: &P)
+// returns true if the pardiso iparm settings are configured
+// in a way that makes sense for clarabel
+pub(crate) fn pardiso_iparm_is_valid(_iparm: &[i32; 64]) -> bool
 where
-    P: PardisoInterface + PardisoCustomInitialize,
 {
-    // pardiso wants b to be mutable since there is an option
-    // to store the solution on b instead of x. We always want
-    // to ensure that b is constant when calling pardiso
-    assert!(
-        ps.get_iparm(5) == 0,
-        "Pardiso should be set to store its solution in x, not b [iparm[5] != 0 error]"
-    );
+    // placeholder for possible pardiso iparm checks.
+    // NB: call comes from user settings, so need
+    // to all u32:MIN values to be treated as "unset"
+    true
 }

--- a/src/solver/core/settings.rs
+++ b/src/solver/core/settings.rs
@@ -12,8 +12,11 @@ pub type CoreSettings<T> = DefaultSettings<T>;
 /// Error type returned by settings validation
 pub enum SettingsError {
     /// An error attributable to one of the fields
-    #[error("Bad field")]
-    BadField(&'static str),
+    #[error("Bad value for field \"{0}\"")]
+    BadFieldValue(&'static str),
+    /// An error thrown when immutable settings are modified within the solver
+    #[error("Attempt to modify immutable setting \"{0}\"")]
+    ImmutableSetting(&'static str),
     /// a subsolver error of some kind (e.g. not found, no license)
     #[error("Problem with {solver} solver ({problem})")]
     LinearSolverProblem {

--- a/src/solver/core/settings.rs
+++ b/src/solver/core/settings.rs
@@ -1,4 +1,5 @@
 use crate::solver::implementations::default::DefaultSettings;
+use thiserror::Error;
 
 /// Solver general core settings are the same as in the default solver.
 ///
@@ -6,3 +7,17 @@ use crate::solver::implementations::default::DefaultSettings;
 /// to view the complete list.
 ///
 pub type CoreSettings<T> = DefaultSettings<T>;
+
+#[derive(Error, Debug)]
+/// Error type returned by settings validation
+pub enum SettingsError {
+    /// An error attributable to one of the fields
+    #[error("Bad field")]
+    BadField(&'static str),
+    /// a subsolver error of some kind (e.g. not found, no license)
+    #[error("Problem with {solver} solver ({problem})")]
+    LinearSolverProblem {
+        solver: &'static str,
+        problem: &'static str,
+    },
+}

--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -201,7 +201,6 @@ where
     }
 
     pub fn update_settings(&mut self, settings: SE) -> Result<(), SettingsError> {
-        settings.validate()?;
         settings.validate_as_update(&self.settings)?;
         self.settings = settings;
         Ok(())

--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -1,10 +1,11 @@
 use self::internal::*;
 use super::callbacks::{Callback, CallbackFcnFFI};
 use super::cones::Cone;
-use super::traits::*;
+use super::{traits::*, SettingsError};
 use crate::algebra::*;
 use crate::solver::core::callbacks::SolverCallbacks;
 use crate::solver::core::ffi::*;
+use crate::solver::SolverError;
 use crate::timers::*;
 use std::io::Write;
 
@@ -106,7 +107,7 @@ where
     fn load_from_file(
         file: &mut std::fs::File,
         settings: Option<crate::solver::DefaultSettings<T>>,
-    ) -> Result<Self, std::io::Error>;
+    ) -> Result<Self, SolverError>;
 }
 
 // ---------------------------------
@@ -121,6 +122,8 @@ where
 pub struct Solver<T, D, V, R, K, C, I, SO, SE>
 where
     I: ClarabelFFI<I>,
+    SE: Settings<T>,
+    T: FloatT,
 {
     pub data: D,
     pub variables: V,
@@ -132,7 +135,7 @@ where
     pub prev_vars: V,
     pub info: I,
     pub solution: SO,
-    pub settings: SE,
+    pub(crate) settings: SE, // not public to avoid unchecked modifications
     pub timers: Option<Timers>,
     pub(crate) callbacks: SolverCallbacks<I, I::FFI>,
     pub(crate) phantom: std::marker::PhantomData<T>,
@@ -177,6 +180,7 @@ fn _print_banner(out: &mut dyn Write, is_verbose: bool) -> std::io::Result<()> {
 impl<T, D, V, R, K, C, I, SO, SE> Solver<T, D, V, R, K, C, I, SO, SE>
 where
     I: Info<T, D = D, V = V, R = R, C = C, SE = SE>,
+    SE: Settings<T>,
     T: FloatT,
 {
     /// Create a new solver object
@@ -190,6 +194,17 @@ where
 
     pub fn unset_termination_callback(&mut self) {
         self.callbacks.termination_callback = Callback::None;
+    }
+
+    pub fn settings(&self) -> &SE {
+        &self.settings
+    }
+
+    pub fn update_settings(&mut self, settings: SE) -> Result<(), SettingsError> {
+        settings.validate()?;
+        settings.validate_as_update(&self.settings)?;
+        self.settings = settings;
+        Ok(())
     }
 }
 

--- a/src/solver/core/traits.rs
+++ b/src/solver/core/traits.rs
@@ -11,7 +11,7 @@
 //! level crate documentation.
 
 use super::ffi::*;
-use super::{cones::Cone, CoreSettings, ScalingStrategy};
+use super::{cones::Cone, CoreSettings, ScalingStrategy, SettingsError};
 use super::{SolverStatus, StepDirection};
 use crate::algebra::*;
 use crate::timers::*;
@@ -259,4 +259,12 @@ pub trait Settings<T: FloatT>: ClarabelFFI<Self> + Sized + Clone {
 
     /// Return the core settings (mutably).
     fn core_mut(&mut self) -> &mut CoreSettings<T>;
+
+    /// sanity check the settings
+    fn validate(&self) -> Result<(), SettingsError>;
+
+    /// check that the settings are a valid update to some previous
+    /// version.   Used to ensure that settings used only at solver
+    /// initialization are not changed during the solve.
+    fn validate_as_update(&self, prev: &Self) -> Result<(), SettingsError>;
 }

--- a/src/solver/implementations/default/settings.rs
+++ b/src/solver/implementations/default/settings.rs
@@ -1,10 +1,13 @@
-use crate::algebra::*;
 use crate::solver::core::ffi::*;
 use crate::solver::core::traits::Settings;
+use crate::{algebra::*, solver::core::SettingsError};
 use derive_builder::Builder;
 
+#[cfg(any(feature = "pardiso-mkl", feature = "pardiso-panua"))]
+use pardiso_wrapper::PardisoInterface;
 #[cfg(feature = "serde")]
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
 #[cfg(all(
     feature = "serde",
     any(feature = "pardiso-mkl", feature = "pardiso-panua")
@@ -253,6 +256,14 @@ where
     }
 }
 
+macro_rules! check_equal_field {
+    ($self:expr, $prev:expr, $field:ident) => {
+        if $self.$field != $prev.$field {
+            return Err(SettingsError::BadField(stringify!($field)));
+        }
+    };
+}
+
 impl<T> Settings<T> for DefaultSettings<T>
 where
     T: FloatT,
@@ -264,6 +275,50 @@ where
     fn core_mut(&mut self) -> &mut DefaultSettings<T> {
         self
     }
+
+    /// Checks that the settings are valid.  This only ensures that fields specified
+    /// by strings contain valid options.   It does not sanity check numerical values
+    fn validate(&self) -> Result<(), SettingsError> {
+        validate_direct_solve_method(&self.direct_solve_method)?;
+
+        // check that the chordal decomposition merge method is valid
+        #[cfg(feature = "sdp")]
+        validate_chordal_decomposition_merge_method(&self.chordal_decomposition_merge_method)?;
+
+        Ok(())
+    }
+
+    /// check that a settings object is valid as an updated collection
+    /// of settings for a solver that has already been initialized.   This
+    /// should reject changed to parameters that are only applicable during
+    /// solver initialization
+    fn validate_as_update(&self, prev: &Self) -> Result<(), SettingsError> {
+        check_equal_field!(self, prev, equilibrate_enable);
+        check_equal_field!(self, prev, equilibrate_max_iter);
+        check_equal_field!(self, prev, equilibrate_min_scaling);
+        check_equal_field!(self, prev, equilibrate_max_scaling);
+        check_equal_field!(self, prev, max_threads);
+        check_equal_field!(self, prev, direct_kkt_solver);
+        check_equal_field!(self, prev, direct_solve_method);
+        check_equal_field!(self, prev, presolve_enable);
+        check_equal_field!(self, prev, input_sparse_dropzeros);
+
+        #[cfg(feature = "sdp")]
+        {
+            check_equal_field!(self, prev, chordal_decomposition_enable);
+            check_equal_field!(self, prev, chordal_decomposition_merge_method);
+            check_equal_field!(self, prev, chordal_decomposition_compact);
+            check_equal_field!(self, prev, chordal_decomposition_complete_dual);
+        }
+
+        #[cfg(any(feature = "pardiso-mkl", feature = "pardiso-panua"))]
+        {
+            check_equal_field!(self, prev, pardiso_iparm);
+            check_equal_field!(self, prev, pardiso_verbose);
+        }
+
+        Ok(())
+    }
 }
 
 impl<T: FloatT> ClarabelFFI<Self> for DefaultSettings<T> {
@@ -272,15 +327,21 @@ impl<T: FloatT> ClarabelFFI<Self> for DefaultSettings<T> {
 
 // pre build checker (for auto-validation when using the builder)
 
+impl From<SettingsError> for DefaultSettingsBuilderError {
+    fn from(e: SettingsError) -> Self {
+        DefaultSettingsBuilderError::ValidationError(e.to_string())
+    }
+}
+
 /// Automatic pre-build settings validation
 impl<T> DefaultSettingsBuilder<T>
 where
     T: FloatT,
 {
     /// check that the specified direct_solve_method is valid
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), SettingsError> {
         if let Some(ref direct_solve_method) = self.direct_solve_method {
-            validate_direct_solve_method(direct_solve_method.as_str())?;
+            validate_direct_solve_method(direct_solve_method)?;
         }
 
         // check that the chordal decomposition merge method is valid
@@ -288,30 +349,8 @@ where
         if let Some(ref chordal_decomposition_merge_method) =
             self.chordal_decomposition_merge_method
         {
-            validate_chordal_decomposition_merge_method(
-                chordal_decomposition_merge_method.as_str(),
-            )?;
+            validate_chordal_decomposition_merge_method(chordal_decomposition_merge_method)?;
         }
-
-        Ok(())
-    }
-}
-
-// post build checker (for ad-hoc validation, e.g. when passing from python/Julia)
-// this is not used directly in the solver, but can be called manually by the user
-
-/// Manual post-build settings validation
-impl<T> DefaultSettings<T>
-where
-    T: FloatT,
-{
-    /// Checks that the settings are valid
-    pub fn validate(&self) -> Result<(), String> {
-        validate_direct_solve_method(&self.direct_solve_method)?;
-
-        // check that the chordal decomposition merge method is valid
-        #[cfg(feature = "sdp")]
-        validate_chordal_decomposition_merge_method(&self.chordal_decomposition_merge_method)?;
 
         Ok(())
     }
@@ -321,33 +360,48 @@ where
 // individual validation functions go here
 // ---------------------------------------------------------
 
-fn validate_direct_solve_method(direct_solve_method: &str) -> Result<(), String> {
+fn validate_direct_solve_method(direct_solve_method: &str) -> Result<(), SettingsError> {
     match direct_solve_method {
         "auto" => Ok(()),
         "qdldl" => Ok(()),
         #[cfg(feature = "faer-sparse")]
         "faer" => Ok(()),
         #[cfg(feature = "pardiso-mkl")]
-        "mkl" => Ok(()),
+        "mkl" => {
+            if pardiso_wrapper::MKLPardisoSolver::is_available() {
+                Ok(())
+            } else {
+                Err(SettingsError::LinearSolverProblem {
+                    solver: "mkl",
+                    problem: "not available",
+                })
+            }
+        }
         #[cfg(feature = "pardiso-panua")]
-        "panua" => Ok(()),
-        _ => Err(format!(
-            "Invalid direct_solve_method: {direct_solve_method:?}"
-        )),
+        "panua" => {
+            if pardiso_wrapper::PanuaPardisoSolver::is_available() {
+                Ok(())
+            } else {
+                Err(SettingsError::LinearSolverProblem {
+                    solver: "panua",
+                    problem: "not available",
+                })
+            }
+        }
+        _ => Err(SettingsError::BadField("direct_solve_method")),
     }
 }
 
 #[cfg(feature = "sdp")]
 fn validate_chordal_decomposition_merge_method(
     chordal_decomposition_merge_method: &str,
-) -> Result<(), String> {
+) -> Result<(), SettingsError> {
     match chordal_decomposition_merge_method {
         "none" => Ok(()),
         "parent_child" => Ok(()),
         "clique_graph" => Ok(()),
-        _ => Err(format!(
-            "Invalid chordal_decomposition_merge_method: {}",
-            chordal_decomposition_merge_method
+        _ => Err(SettingsError::BadField(
+            "chordal_decomposition_merge_method",
         )),
     }
 }
@@ -375,11 +429,41 @@ fn test_settings_validate() {
             assert!(builder.is_err());
         }
     }
-
     #[cfg(feature = "sdp")]
     // fail on unknown chordal decomposition merge method
     assert!(DefaultSettingsBuilder::<f64>::default()
         .chordal_decomposition_merge_method("foo".to_string())
         .build()
         .is_err());
+
+    // directly construct a bad DefaultSettings and manually check
+    let settings = DefaultSettings::<f64> {
+        direct_solve_method: "foo".to_string(),
+        ..DefaultSettings::default()
+    };
+    assert!(settings.validate().is_err());
+
+    // try to overlay prohibited update values
+    let oldsettings = DefaultSettings::<f64> {
+        presolve_enable: false,
+        ..DefaultSettings::default()
+    };
+
+    let newsettings = DefaultSettings::<f64> {
+        presolve_enable: true,
+        ..DefaultSettings::default()
+    };
+    assert!(newsettings.validate_as_update(&oldsettings).is_err());
+
+    // try to overlay allowed update values
+    let oldsettings = DefaultSettings::<f64> {
+        max_iter: 10,
+        ..DefaultSettings::default()
+    };
+
+    let newsettings = DefaultSettings::<f64> {
+        max_iter: 11,
+        ..DefaultSettings::default()
+    };
+    assert!(newsettings.validate_as_update(&oldsettings).is_ok());
 }

--- a/src/solver/implementations/default/solver.rs
+++ b/src/solver/implementations/default/solver.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::solver::core::callbacks::SolverCallbacks;
+use crate::solver::traits::Settings;
 use crate::{
     io::ConfigurablePrintTarget,
     solver::core::{
@@ -63,6 +64,8 @@ where
     ) -> Result<Self, SolverError> {
         //sanity check problem dimensions
         check_dimensions(P, q, A, b, cones)?;
+        //sanity check settings
+        settings.validate()?;
 
         let mut timers = Timers::default();
         let mut output;

--- a/src/solver/implementations/default/solver.rs
+++ b/src/solver/implementations/default/solver.rs
@@ -6,9 +6,10 @@ use crate::{
         cones::{CompositeCone, SupportedConeT},
         kktsolvers::HasLinearSolverInfo,
         traits::ProblemData,
-        Solver,
+        SettingsError, Solver,
     },
 };
+use thiserror::Error;
 
 use crate::algebra::*;
 use crate::timers::*;
@@ -26,6 +27,28 @@ pub type DefaultSolver<T = f64> = Solver<
     DefaultSettings<T>,
 >;
 
+/// Error types returned by the DefaultSolver
+
+#[derive(Error, Debug)]
+/// Error type returned by settings validation
+pub enum SolverError {
+    /// An error attributable to one of the fields
+    #[error("Bad input data: {0}")]
+    BadInputData(&'static str),
+
+    /// Error from settings validation with details
+    #[error("Bad settings: {0}")]
+    SettingsError(#[from] SettingsError),
+
+    /// Error from I/O operations
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// Error from JSON parsing/serialization
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
 impl<T> DefaultSolver<T>
 where
     T: FloatT,
@@ -37,9 +60,9 @@ where
         b: &[T],
         cones: &[SupportedConeT<T>],
         settings: DefaultSettings<T>,
-    ) -> Self {
+    ) -> Result<Self, SolverError> {
         //sanity check problem dimensions
-        _check_dimensions(P, q, A, b, cones);
+        check_dimensions(P, q, A, b, cones)?;
 
         let mut timers = Timers::default();
         let mut output;
@@ -96,29 +119,40 @@ where
         //timer object into the solver structure
         output.timers.replace(timers);
 
-        output
+        Ok(output)
     }
 }
 
-fn _check_dimensions<T: FloatT>(
+fn check_dimensions<T: FloatT>(
     P: &CscMatrix<T>,
     q: &[T],
     A: &CscMatrix<T>,
     b: &[T],
     cone_types: &[SupportedConeT<T>],
-) {
+) -> Result<(), SolverError> {
     let m = b.len();
     let n = q.len();
     let p = cone_types.iter().fold(0, |acc, cone| acc + cone.nvars());
 
-    assert!(m == A.nrows(), "A and b incompatible dimensions.");
-    assert!(
-        p == m,
-        "Constraint dimensions inconsistent with size of cones."
-    );
-    assert!(n == A.ncols(), "A and q incompatible dimensions.");
-    assert!(n == P.ncols(), "P and q incompatible dimensions.");
-    assert!(P.is_square(), "P not square.");
+    if m != A.nrows() {
+        return Err(SolverError::BadInputData("A and b incompatible dimensions"));
+    }
+    if p != m {
+        return Err(SolverError::BadInputData(
+            "Constraint dimensions inconsistent with size of cones",
+        ));
+    }
+    if n != A.ncols() {
+        return Err(SolverError::BadInputData("A and q incompatible dimensions"));
+    }
+    if n != P.ncols() {
+        return Err(SolverError::BadInputData("P and q incompatible dimensions"));
+    }
+    if !P.is_square() {
+        return Err(SolverError::BadInputData("P not square"));
+    }
+
+    Ok(())
 }
 
 impl<T> ConfigurablePrintTarget for DefaultSolver<T>

--- a/tests/api_dimension_checks.rs
+++ b/tests/api_dimension_checks.rs
@@ -33,51 +33,46 @@ fn api_dim_check_working() {
 }
 
 #[test]
-#[should_panic]
 fn api_dim_check_bad_P() {
     let (_P, q, A, b, cones) = api_dim_check_data();
     let P = CscMatrix::<f64>::zeros((3, 3));
 
     let settings = DefaultSettings::default();
-    let _solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    assert!(DefaultSolver::new(&P, &q, &A, &b, &cones, settings).is_err());
 }
 
 #[test]
-#[should_panic]
 fn api_dim_check_bad_A_rows() {
     let (P, q, _A, b, cones) = api_dim_check_data();
     let A = CscMatrix::<f64>::zeros((5, 4));
 
     let settings = DefaultSettings::default();
-    let _solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    assert!(DefaultSolver::new(&P, &q, &A, &b, &cones, settings).is_err());
 }
 
 #[test]
-#[should_panic]
 fn api_dim_check_bad_A_cols() {
     let (P, q, _A, b, cones) = api_dim_check_data();
     let A = CscMatrix::<f64>::zeros((6, 3));
 
     let settings = DefaultSettings::default();
-    let _solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    assert!(DefaultSolver::new(&P, &q, &A, &b, &cones, settings).is_err());
 }
 
 #[test]
-#[should_panic]
 fn api_dim_check_P_not_square() {
     let (_P, q, A, b, cones) = api_dim_check_data();
     let P = CscMatrix::<f64>::zeros((4, 3));
 
     let settings = DefaultSettings::default();
-    let _solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    assert!(DefaultSolver::new(&P, &q, &A, &b, &cones, settings).is_err());
 }
 
 #[test]
-#[should_panic]
 fn api_dim_check_bad_cones() {
     let (P, q, A, b, _cones) = api_dim_check_data();
     let cones = vec![ZeroConeT(1), NonnegativeConeT(2), NonnegativeConeT(4)];
 
     let settings = DefaultSettings::default();
-    let _solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    assert!(DefaultSolver::new(&P, &q, &A, &b, &cones, settings).is_err());
 }

--- a/tests/basic_eq_constrained.rs
+++ b/tests/basic_eq_constrained.rs
@@ -40,7 +40,7 @@ fn test_eq_constrained_feasible() {
     let cones = [ZeroConeT(2)];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
     let refsol = [0., 1., 1.];
@@ -57,7 +57,7 @@ fn test_eq_constrained_primal_infeasible() {
     let cones = [ZeroConeT(4)];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
     assert_eq!(solver.solution.status, SolverStatus::PrimalInfeasible);
@@ -73,7 +73,7 @@ fn test_eq_constrained_dual_infeasible() {
     let cones = [ZeroConeT(2)];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
     assert_eq!(solver.solution.status, SolverStatus::DualInfeasible);

--- a/tests/basic_expcone.rs
+++ b/tests/basic_expcone.rs
@@ -51,7 +51,7 @@ fn test_expcone_feasible() {
     let (P, c, A, b, cones) = basic_expcone_data();
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -78,7 +78,7 @@ fn test_expcone_primal_infeasible() {
     b[4] = -1.; //
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -102,7 +102,7 @@ fn test_expcone_dual_infeasible() {
     let cones = vec![ExponentialConeT()];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_genpowcone.rs
+++ b/tests/basic_genpowcone.rs
@@ -44,7 +44,7 @@ fn test_powcone() {
     let cones = [cones1, cones2].concat();
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_lp.rs
+++ b/tests/basic_lp.rs
@@ -32,7 +32,7 @@ fn test_lp_feasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -55,7 +55,7 @@ fn test_lp_primal_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -73,7 +73,7 @@ fn test_lp_dual_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -92,7 +92,7 @@ fn test_lp_dual_infeasible_ill_cond() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_powcone.rs
+++ b/tests/basic_powcone.rs
@@ -41,7 +41,7 @@ fn test_powcone() {
     let cones = [cones1, cones2].concat();
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_qp.rs
+++ b/tests/basic_qp.rs
@@ -85,7 +85,7 @@ fn test_qp_univariate() {
     let cones = [NonnegativeConeT(1)];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -102,7 +102,7 @@ fn test_qp_feasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -121,17 +121,17 @@ fn test_qp_singleton_constraints() {
     // problem with standard cones
     let (P, c, A, b, cones) = basic_qp_data();
     let settings = DefaultSettings::default();
-    let mut solver1 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     //problem with singleton constraints
     let cones = vec![NonnegativeConeT(1); 6];
-    let mut solver2 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+    let mut solver2 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
     solver2.solve();
 
     //problem with SOC singleton constraints
     let cones = vec![SecondOrderConeT(1); 6];
-    let mut solver3 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+    let mut solver3 = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
     solver3.solve();
     assert_eq!(solver1.solution.status, solver2.solution.status);
     assert_eq!(solver1.solution.status, solver3.solution.status);
@@ -150,7 +150,7 @@ fn test_qp_primal_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -165,7 +165,7 @@ fn test_qp_dual_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -192,7 +192,7 @@ fn test_qp_dual_infeasible_ill_cond() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_sdp.rs
+++ b/tests/basic_sdp.rs
@@ -47,7 +47,7 @@ fn test_sdp_feasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -65,7 +65,7 @@ fn test_sdp_empty_cone() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -87,7 +87,7 @@ fn test_sdp_primal_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_socp.rs
+++ b/tests/basic_socp.rs
@@ -58,7 +58,7 @@ fn test_socp_feasible() {
 
     let settings = DefaultSettings::<f64>::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -81,7 +81,7 @@ fn test_socp_feasible_sparse() {
 
     let settings = DefaultSettings::<f64>::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -97,7 +97,7 @@ fn test_socp_infeasible() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/basic_unconstrained.rs
+++ b/tests/basic_unconstrained.rs
@@ -11,7 +11,7 @@ fn test_unconstrained_feasible() {
     let cones = [];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -29,7 +29,7 @@ fn test_unconstrained_dual_infeasible() {
     let cones = [];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
     assert_eq!(solver.solution.status, SolverStatus::DualInfeasible);

--- a/tests/data_updating.rs
+++ b/tests/data_updating.rs
@@ -47,7 +47,7 @@ fn updating_test_data() -> (
 fn test_update_P_matrix_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // change P and re-solve
@@ -59,7 +59,7 @@ fn test_update_P_matrix_form() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -69,7 +69,7 @@ fn test_update_P_matrix_form() {
 fn test_update_P_vector_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // change P and re-solve
@@ -81,7 +81,7 @@ fn test_update_P_vector_form() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -91,7 +91,7 @@ fn test_update_P_vector_form() {
 fn test_update_P_tuple() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // revised original solver
@@ -107,7 +107,7 @@ fn test_update_P_tuple() {
         [P00, 3.], //
         [0., 5.],  //
     ]);
-    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P2, &q, &A, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -117,7 +117,7 @@ fn test_update_P_tuple() {
 fn test_update_A_matrix_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     //solver1.solve();
 
     // change A and re-solve
@@ -132,7 +132,7 @@ fn test_update_A_matrix_form() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -142,7 +142,7 @@ fn test_update_A_matrix_form() {
 fn test_update_A_vector_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // change A and re-solve
@@ -157,7 +157,7 @@ fn test_update_A_vector_form() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -167,7 +167,7 @@ fn test_update_A_vector_form() {
 fn test_update_A_tuple_form() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // revised original solver
@@ -181,7 +181,7 @@ fn test_update_A_tuple_form() {
     let mut A2 = A;
     A2.nzval[1] = 0.5;
     A2.nzval[2] = -0.5;
-    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q, &A2, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -191,7 +191,7 @@ fn test_update_A_tuple_form() {
 fn test_update_q() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // change 1 and re-solve
@@ -203,7 +203,7 @@ fn test_update_q() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -213,7 +213,7 @@ fn test_update_q() {
 fn test_update_q_tuple() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // revised original solver
@@ -226,7 +226,7 @@ fn test_update_q_tuple() {
     //new solver
     let mut q2 = q;
     q2[1] = 10.;
-    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q2, &A, &b, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -236,7 +236,7 @@ fn test_update_q_tuple() {
 fn test_update_b() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // change 1 and re-solve
@@ -248,7 +248,7 @@ fn test_update_b() {
     solver1.solve();
 
     //new solver
-    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -258,7 +258,7 @@ fn test_update_b() {
 fn test_update_b_tuple() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver1 = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     solver1.solve();
 
     // revised original solver
@@ -270,7 +270,7 @@ fn test_update_b_tuple() {
 
     //new solver
     let b2 = vec![1., 0., 1., 0.];
-    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings);
+    let mut solver2 = DefaultSolver::new(&P, &q, &A, &b2, &cones, settings).unwrap();
     solver2.solve();
 
     assert!(solver1.solution.x.dist(&solver2.solution.x) <= 1e-7);
@@ -280,7 +280,7 @@ fn test_update_b_tuple() {
 fn test_update_noops() {
     // original problem
     let (P, q, A, b, cones, settings) = updating_test_data();
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings).unwrap();
     solver.solve();
 
     // apply no-op updates to check for crashes
@@ -312,7 +312,7 @@ fn test_fail_on_presolve_enable() {
     // original problem
     let (P, q, A, mut b, cones, mut settings) = updating_test_data();
     settings.presolve_enable = true;
-    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
 
     // presolve enabled but nothing eliminated
     assert!(solver.is_data_update_allowed());
@@ -320,13 +320,13 @@ fn test_fail_on_presolve_enable() {
     // presolved disabled in settings
     b[0] = 1e40;
     settings.presolve_enable = false;
-    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     assert!(solver.is_data_update_allowed());
 
     // should be eliminated
     b[0] = 1e40;
     settings.presolve_enable = true;
-    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone());
+    let mut solver = DefaultSolver::new(&P, &q, &A, &b, &cones, settings.clone()).unwrap();
     assert!(!solver.is_data_update_allowed());
 
     // apply no-op updates to check that updates are rejected

--- a/tests/equilibration_bounds.rs
+++ b/tests/equilibration_bounds.rs
@@ -47,7 +47,7 @@ fn test_equilibrate_lower_bound() {
 
     P.nzval[0] = 1e-15;
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
 
     solver.solve();
 
@@ -71,7 +71,7 @@ fn test_equilibrate_upper_bound() {
         .build()
         .unwrap();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
 
     let d = &solver.data.equilibration.d;
     let e = &solver.data.equilibration.e;
@@ -93,7 +93,7 @@ fn test_equilibrate_zero_rows() {
 
     A.nzval.set(0.0);
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/json_io.rs
+++ b/tests/json_io.rs
@@ -26,7 +26,7 @@ fn test_json_io() {
 
     let settings = DefaultSettingsBuilder::default().build().unwrap();
 
-    let mut solver = DefaultSolver::<f64>::new(&P, &q, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::<f64>::new(&P, &q, &A, &b, &cones, settings).unwrap();
     solver.solve();
 
     // write the problem to a file

--- a/tests/mixed_conic.rs
+++ b/tests/mixed_conic.rs
@@ -31,7 +31,7 @@ fn test_mixed_conic_feasible() {
     let b = vec![0.; 5 * n];
 
     let settings = DefaultSettings::default();
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
     assert_eq!(solver.solution.status, SolverStatus::Solved);
@@ -41,8 +41,12 @@ fn test_mixed_conic_feasible() {
     // it forces the solver to use the barrier method for
     // non-symmetric cones.   This hits some code paths
     // that are otherwise not tested
-    solver.settings.min_switch_step_length = 0.999;
+    let new_settings = DefaultSettings {
+        min_switch_step_length: 0.999,
+        ..DefaultSettings::default()
+    };
 
+    solver.update_settings(new_settings).unwrap();
     solver.solve();
     assert_eq!(solver.solution.status, SolverStatus::Solved);
     assert!(f64::abs(solver.info.cost_primal - 0.) <= 1e-8);

--- a/tests/presolve.rs
+++ b/tests/presolve.rs
@@ -34,7 +34,7 @@ fn test_presolve_single_unbounded() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -55,7 +55,7 @@ fn test_presolve_single_unbounded_2() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -73,7 +73,7 @@ fn test_presolve_completely_redundant_cone() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 
@@ -94,7 +94,7 @@ fn test_presolve_every_constraint_redundant() {
 
     let settings = DefaultSettings::default();
 
-    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings);
+    let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap();
 
     solver.solve();
 

--- a/tests/print_streams.rs
+++ b/tests/print_streams.rs
@@ -10,7 +10,7 @@ fn test_print_solver() -> DefaultSolver<f64> {
     let b = [1.];
     let cones = [NonnegativeConeT(1)];
     let settings = DefaultSettings::default();
-    DefaultSolver::new(&P, &c, &A, &b, &cones, settings)
+    DefaultSolver::new(&P, &c, &A, &b, &cones, settings).unwrap()
 }
 
 #[test]

--- a/tests/sdp_chordal.rs
+++ b/tests/sdp_chordal.rs
@@ -104,7 +104,8 @@ fn test_sdp_chordal() {
                 settings.chordal_decomposition_compact = compact;
                 settings.chordal_decomposition_complete_dual = complete_dual;
                 settings.chordal_decomposition_merge_method = merge_method.to_string();
-                let mut solver = DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone());
+                let mut solver =
+                    DefaultSolver::new(&P, &c, &A, &b, &cones, settings.clone()).unwrap();
                 solver.solve();
                 assert_eq!(solver.solution.status, SolverStatus::Solved);
             }


### PR DESCRIPTION
Solver constructor now returns a Result, with error messages returned if the supplied data and settings are somehow inconsistent.    Adds updating methods for settings so that immutable settings (e.g. LDL subsolver choice) can't be modified when solving multiple times.   Fixes #169.   