### PR TITLE
direct inclusion of mkl dylibs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,13 @@ buildinfo = ["dep:vergen"]
 sdp-accelerate = ["sdp", "blas-src/accelerate", "lapack-src/accelerate"]
 sdp-netlib     = ["sdp", "blas-src/netlib", "lapack-src/netlib", "netlib-src"]
 sdp-openblas   = ["sdp", "blas-src/openblas", "lapack-src/openblas", "openblas-src"]
-sdp-mkl        = ["sdp", "blas-src/intel-mkl", "lapack-src/intel-mkl","intel-mkl-src"]
 sdp-r          = ["sdp", "blas-src/r", "lapack-src/r"]
+
+# static linking for intel mkl
+sdp-mkl        = ["sdp", "blas-src/intel-mkl", "lapack-src/intel-mkl","intel-mkl-src"]
+
+# dynamic linking for intel mkl
+sdp-mkl-system = ["sdp","blas-src","lapack-src"]
 
 # build as the julia interface 
 julia = [

--- a/build.rs
+++ b/build.rs
@@ -10,10 +10,14 @@ macro_rules! printinfo {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "sdp-mkl-system")]
+    config_intel_mkl_system()?;
+
     config_python_blas();
 
     #[cfg(feature = "buildinfo")]
     config_build_info()?;
+
     Ok(())
 }
 
@@ -59,4 +63,23 @@ fn config_python_blas() {
     } else {
         printinfo!("Python: compiling with local blas/lapack libraries");
     }
+}
+
+#[cfg(feature = "sdp-mkl-system")]
+fn config_intel_mkl_system() -> Result<(), Box<dyn Error>> {
+    // this assumes that that the MKLROOT directory is on the
+    // PATH, LD_LIBRARY_PATH or DYLD_LIBRARY_PATH.   This is
+    // configuring for the same library version as the one selected
+    // by intel-mkl-src with the mkl-dynamic-lp64-iomp feature.
+
+    // NB: this is implemented this way because the intel-mkl-src
+    // crate is a very heavy dependency.   Specifying sdp-mkl-system
+    // indicates that the user has taken responsibility for install,
+    // and path configuration and wants the system MKL installation.§
+
+    println!("cargo:rustc-link-lib=dylib=mkl_intel_lp64");
+    println!("cargo:rustc-link-lib=dylib=mkl_intel_thread");
+    println!("cargo:rustc-link-lib=dylib=mkl_core");
+    println!("cargo:rustc-link-lib=dylib=iomp5");
+    Ok(())
 }


### PR DESCRIPTION
The intel-mkl-src crate has a very large dependency tree, nearly all of which relates to import/download of static libraries.    This is not needed for dynamic linking to MKL.

This PR adds a new 'sdp-mkl-system' feature that skips this dependency and links directly to MKL dylibs.  These must be available on the system path (via PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH etc).