### PR TITLE
remove lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ cfg-if         = "1.0"
 itertools      = "0.11"
 derive_builder = "0.11"
 enum_dispatch  = "0.3.8"
-lazy_static    = "1.4"
 num-traits     = "0.2"
 thiserror      = "1.0"
 

--- a/src/python/pyblas/blas_wrappers.rs
+++ b/src/python/pyblas/blas_wrappers.rs
@@ -3,26 +3,30 @@
 #![allow(dead_code)]
 
 use super::blas_types::*;
-use lazy_static::lazy_static;
 use libc::c_char;
+use std::sync::OnceLock;
 
-lazy_static! {
-    static ref PYBLAS: PyBlasPointers = pyo3::Python::with_gil(|py| {
-        PyBlasPointers::new(py).expect("Failed to load SciPy BLAS bindings.")
-    });
+static PYBLAS: OnceLock<PyBlasPointers> = OnceLock::new();
+
+fn get_pyblas() -> &'static PyBlasPointers {
+    PYBLAS.get_or_init(|| {
+        pyo3::Python::with_gil(|py| {
+            PyBlasPointers::new(py).expect("Failed to load SciPy BLAS bindings.")
+        })
+    })
 }
 
 pub(crate) fn force_load() {
-    //forces load of the lazy_static.   Choice of function is arbitrary.
-    let _ = PYBLAS.ddot_;
+    //forces load of the lazy static. Choice of function is arbitrary.
+    let _ = get_pyblas().ddot_;
 }
 
 pub unsafe fn ddot(n: i32, x: &[f64], incx: i32, y: &[f64], incy: i32) -> f64 {
-    (PYBLAS.ddot_)(&n, x.as_ptr(), &incx, y.as_ptr(), &incy)
+    (get_pyblas().ddot_)(&n, x.as_ptr(), &incx, y.as_ptr(), &incy)
 }
 
 pub unsafe fn sdot(n: i32, x: &[f32], incx: i32, y: &[f32], incy: i32) -> f32 {
-    (PYBLAS.sdot_)(&n, x.as_ptr(), &incx, y.as_ptr(), &incy)
+    (get_pyblas().sdot_)(&n, x.as_ptr(), &incx, y.as_ptr(), &incy)
 }
 
 pub unsafe fn dgemm(
@@ -40,7 +44,7 @@ pub unsafe fn dgemm(
     c: &mut [f64],
     ldc: i32,
 ) {
-    (PYBLAS.dgemm_)(
+    (get_pyblas().dgemm_)(
         &(transa as c_char),
         &(transb as c_char),
         &m,
@@ -56,6 +60,7 @@ pub unsafe fn dgemm(
         &ldc,
     )
 }
+
 pub unsafe fn sgemm(
     transa: u8,
     transb: u8,
@@ -71,7 +76,7 @@ pub unsafe fn sgemm(
     c: &mut [f32],
     ldc: i32,
 ) {
-    (PYBLAS.sgemm_)(
+    (get_pyblas().sgemm_)(
         &(transa as c_char),
         &(transb as c_char),
         &m,
@@ -101,7 +106,7 @@ pub unsafe fn dgemv(
     y: &mut [f64],
     incy: i32,
 ) {
-    (PYBLAS.dgemv_)(
+    (get_pyblas().dgemv_)(
         &(trans as c_char),
         &m,
         &n,
@@ -129,7 +134,7 @@ pub unsafe fn sgemv(
     y: &mut [f32],
     incy: i32,
 ) {
-    (PYBLAS.sgemv_)(
+    (get_pyblas().sgemv_)(
         &(trans as c_char),
         &m,
         &n,
@@ -156,7 +161,7 @@ pub unsafe fn dsymv(
     y: &mut [f64],
     incy: i32,
 ) {
-    (PYBLAS.dsymv_)(
+    (get_pyblas().dsymv_)(
         &(uplo as c_char),
         &n,
         &alpha,
@@ -182,7 +187,7 @@ pub unsafe fn ssymv(
     y: &mut [f32],
     incy: i32,
 ) {
-    (PYBLAS.ssymv_)(
+    (get_pyblas().ssymv_)(
         &(uplo as c_char),
         &n,
         &alpha,
@@ -208,7 +213,7 @@ pub unsafe fn dsyrk(
     c: &mut [f64],
     ldc: i32,
 ) {
-    (PYBLAS.dsyrk_)(
+    (get_pyblas().dsyrk_)(
         &(uplo as c_char),
         &(trans as c_char),
         &n,
@@ -234,7 +239,7 @@ pub unsafe fn ssyrk(
     c: &mut [f32],
     ldc: i32,
 ) {
-    (PYBLAS.ssyrk_)(
+    (get_pyblas().ssyrk_)(
         &(uplo as c_char),
         &(trans as c_char),
         &n,
@@ -262,7 +267,7 @@ pub unsafe fn dsyr2k(
     c: &mut [f64],
     ldc: i32,
 ) {
-    (PYBLAS.dsyr2k_)(
+    (get_pyblas().dsyr2k_)(
         &(uplo as c_char),
         &(trans as c_char),
         &n,
@@ -292,7 +297,7 @@ pub unsafe fn ssyr2k(
     c: &mut [f32],
     ldc: i32,
 ) {
-    (PYBLAS.ssyr2k_)(
+    (get_pyblas().ssyr2k_)(
         &(uplo as c_char),
         &(trans as c_char),
         &n,

--- a/src/python/pyblas/lapack_wrappers.rs
+++ b/src/python/pyblas/lapack_wrappers.rs
@@ -2,18 +2,22 @@
 #![allow(clippy::missing_safety_doc)]
 
 use super::lapack_types::*;
-use lazy_static::lazy_static;
 use libc::c_char;
+use std::sync::OnceLock;
 
-lazy_static! {
-    static ref PYLAPACK: PyLapackPointers = pyo3::Python::with_gil(|py| {
-        PyLapackPointers::new(py).expect("Failed to load SciPy LAPACK bindings.")
-    });
+static PYLAPACK: OnceLock<PyLapackPointers> = OnceLock::new();
+
+fn get_pylapack() -> &'static PyLapackPointers {
+    PYLAPACK.get_or_init(|| {
+        pyo3::Python::with_gil(|py| {
+            PyLapackPointers::new(py).expect("Failed to load SciPy LAPACK bindings.")
+        })
+    })
 }
 
 pub(crate) fn force_load() {
-    //forces load of the lazy_static.   Choice of function is arbitrary.
-    let _ = PYLAPACK.dsyevr_;
+    // forces initialization
+    let _ = get_pylapack().dsyevr_;
 }
 
 pub unsafe fn dsyevr(
@@ -39,7 +43,7 @@ pub unsafe fn dsyevr(
     liwork: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.dsyevr_)(
+    (get_pylapack().dsyevr_)(
         &(jobz as c_char),
         &(range as c_char),
         &(uplo as c_char),
@@ -87,7 +91,7 @@ pub unsafe fn ssyevr(
     liwork: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.ssyevr_)(
+    (get_pylapack().ssyevr_)(
         &(jobz as c_char),
         &(range as c_char),
         &(uplo as c_char),
@@ -113,11 +117,11 @@ pub unsafe fn ssyevr(
 }
 
 pub unsafe fn dpotrf(uplo: u8, n: i32, a: &mut [f64], lda: i32, info: &mut i32) {
-    (PYLAPACK.dpotrf_)(&(uplo as c_char), &n, a.as_mut_ptr(), &lda, info)
+    (get_pylapack().dpotrf_)(&(uplo as c_char), &n, a.as_mut_ptr(), &lda, info)
 }
 
 pub unsafe fn spotrf(uplo: u8, n: i32, a: &mut [f32], lda: i32, info: &mut i32) {
-    (PYLAPACK.spotrf_)(&(uplo as c_char), &n, a.as_mut_ptr(), &lda, info)
+    (get_pylapack().spotrf_)(&(uplo as c_char), &n, a.as_mut_ptr(), &lda, info)
 }
 
 pub unsafe fn dpotrs(
@@ -130,7 +134,7 @@ pub unsafe fn dpotrs(
     ldb: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.dpotrs_)(
+    (get_pylapack().dpotrs_)(
         &(uplo as c_char),
         &n,
         &nrhs,
@@ -152,7 +156,7 @@ pub unsafe fn spotrs(
     ldb: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.spotrs_)(
+    (get_pylapack().spotrs_)(
         &(uplo as c_char),
         &n,
         &nrhs,
@@ -180,7 +184,7 @@ pub unsafe fn dgesdd(
     iwork: &mut [i32],
     info: &mut i32,
 ) {
-    (PYLAPACK.dgesdd_)(
+    (get_pylapack().dgesdd_)(
         &(jobz as c_char),
         &m,
         &n,
@@ -214,7 +218,7 @@ pub unsafe fn sgesdd(
     iwork: &mut [i32],
     info: &mut i32,
 ) {
-    (PYLAPACK.sgesdd_)(
+    (get_pylapack().sgesdd_)(
         &(jobz as c_char),
         &m,
         &n,
@@ -248,7 +252,7 @@ pub unsafe fn dgesvd(
     lwork: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.dgesvd_)(
+    (get_pylapack().dgesvd_)(
         &(jobu as c_char),
         &(jobvt as c_char),
         &m,
@@ -282,7 +286,7 @@ pub unsafe fn sgesvd(
     lwork: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.sgesvd_)(
+    (get_pylapack().sgesvd_)(
         &(jobu as c_char),
         &(jobvt as c_char),
         &m,
@@ -310,7 +314,7 @@ pub unsafe fn dgesv(
     ldb: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.dgesv_)(
+    (get_pylapack().dgesv_)(
         &n,
         &nrhs,
         a.as_mut_ptr(),
@@ -332,7 +336,7 @@ pub unsafe fn sgesv(
     ldb: i32,
     info: &mut i32,
 ) {
-    (PYLAPACK.sgesv_)(
+    (get_pylapack().sgesv_)(
         &n,
         &nrhs,
         a.as_mut_ptr(),

--- a/src/python/pyblas/mod.rs
+++ b/src/python/pyblas/mod.rs
@@ -17,9 +17,9 @@ mod lapack_loader;
 mod lapack_types;
 
 // a function to force instantiation of the blas/lapack wrappers
-// stored in lazy_statics.   This function can be called during
-// initialization of the python module to ensure that lazy_statics
-// are already realised before making an FFI call to blas/lapack.
+// stored in OnceLock statics.   This function can be called during
+// initialization of the python module to ensure that libraries
+// are already loaded before making an FFI call to blas/lapack.
 pub fn force_load() {
     blas_wrappers::force_load();
     lapack_wrappers::force_load();

--- a/src/utils/infbounds.rs
+++ b/src/utils/infbounds.rs
@@ -1,5 +1,5 @@
 use crate::utils::atomic::{AtomicF64, Ordering};
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
 /// Constant indicating that an inequality bound is to be treated as infinite.
 ///   
@@ -12,25 +12,29 @@ use lazy_static::lazy_static;
 ///
 pub const INFINITY_DEFAULT: f64 = crate::_INFINITY_DEFAULT;
 
-lazy_static! {
-    static ref INFINITY: AtomicF64 = AtomicF64::new(INFINITY_DEFAULT);
+static INFINITY: OnceLock<AtomicF64> = OnceLock::new();
+
+fn get_infinity_cell() -> &'static AtomicF64 {
+    INFINITY.get_or_init(|| AtomicF64::new(INFINITY_DEFAULT))
 }
 
 /// Revert internal infinity bound to its default value.   The default is [`INFINITY_DEFAULT`]
 ///
 /// See also: [`get_infinity`], [`set_infinity`]
 pub fn default_infinity() {
-    INFINITY.store(INFINITY_DEFAULT, Ordering::Relaxed);
+    get_infinity_cell().store(INFINITY_DEFAULT, Ordering::Relaxed);
 }
+
 /// Set the internal infinity bound to a new value.
 ///
 /// See also: [`get_infinity`], [`default_infinity`]
 pub fn set_infinity(v: f64) {
-    INFINITY.store(v, Ordering::Relaxed);
+    get_infinity_cell().store(v, Ordering::Relaxed);
 }
+
 /// Get the current value of the internal infinity bound.
 ///
 /// See also: [`set_infinity`], [`default_infinity`]
 pub fn get_infinity() -> f64 {
-    INFINITY.load(Ordering::Relaxed)
+    get_infinity_cell().load(Ordering::Relaxed)
 }


### PR DESCRIPTION
Removes the dependency on the lazy_static crate in favour of `std::sync::OnceLock`.  