### PR TITLE
Fall back to the best iterate when terminating with a numerical error

### DIFF
--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -307,7 +307,8 @@ where
 
             // remember the best iterate seen so far, so that a later numerical
             // failure can fall back to it rather than a degraded final iterate
-            self.info.save_best_iterate(&self.variables, &mut self.best_vars);
+            self.info
+                .save_best_iterate(&self.variables, &mut self.best_vars, &self.settings);
 
             // termination checks
             // --------------
@@ -454,9 +455,18 @@ where
         timeit! {timers => "post-process"; {
             // on numerical failure the final iterate is often severely degraded
             // (e.g. a blown-up primal residual): fall back to the best iterate
-            // seen so that the "almost" convergence check below applies to it
-            if self.info.get_status().is_errored() {
-                self.info.reset_to_best_iterate(&mut self.variables, &self.best_vars);
+            // seen so that the "almost" convergence check below applies to it.
+            // Iteration and time limits are included because `post_process`
+            // runs that same check for them, and their final iterate is no more
+            // likely to be the best one seen than a failed solve's is.
+            if self.info.get_status().is_errored()
+                || matches!(
+                    self.info.get_status(),
+                    SolverStatus::MaxIterations | SolverStatus::MaxTime
+                )
+            {
+                self.info
+                    .reset_to_best_iterate(&mut self.variables, &self.best_vars, &self.settings);
             }
 
             //check for "almost" convergence case and then extract solution

--- a/src/solver/core/solver.rs
+++ b/src/solver/core/solver.rs
@@ -133,6 +133,7 @@ where
     pub step_lhs: V,
     pub step_rhs: V,
     pub prev_vars: V,
+    pub best_vars: V,
     pub info: I,
     pub solution: SO,
     pub(crate) settings: SE, // not public to avoid unchecked modifications
@@ -304,6 +305,10 @@ where
                 self.info.print_status(&self.settings).unwrap();
             }}
 
+            // remember the best iterate seen so far, so that a later numerical
+            // failure can fall back to it rather than a degraded final iterate
+            self.info.save_best_iterate(&self.variables, &mut self.best_vars);
+
             // termination checks
             // --------------
 
@@ -447,6 +452,13 @@ where
         }
 
         timeit! {timers => "post-process"; {
+            // on numerical failure the final iterate is often severely degraded
+            // (e.g. a blown-up primal residual): fall back to the best iterate
+            // seen so that the "almost" convergence check below applies to it
+            if self.info.get_status().is_errored() {
+                self.info.reset_to_best_iterate(&mut self.variables, &self.best_vars);
+            }
+
             //check for "almost" convergence case and then extract solution
             self.info.post_process(&self.residuals, &self.settings);
             self.solution

--- a/src/solver/core/traits.rs
+++ b/src/solver/core/traits.rs
@@ -213,9 +213,19 @@ where
     fn reset_to_prev_iterate(&mut self, variables: &mut Self::V, prev_variables: &Self::V);
 
     /// save the current iterate as the best seen so far if it improves on it
-    fn save_best_iterate(&mut self, variables: &Self::V, best_variables: &mut Self::V);
+    fn save_best_iterate(
+        &mut self,
+        variables: &Self::V,
+        best_variables: &mut Self::V,
+        settings: &Self::SE,
+    );
     /// restore the best iterate seen if it improves on the current one
-    fn reset_to_best_iterate(&mut self, variables: &mut Self::V, best_variables: &Self::V);
+    fn reset_to_best_iterate(
+        &mut self,
+        variables: &mut Self::V,
+        best_variables: &Self::V,
+        settings: &Self::SE,
+    );
 
     /// Record some of the top level solver's choice of various
     /// scalars. `μ = ` normalized gap.  `α = ` computed step length.

--- a/src/solver/core/traits.rs
+++ b/src/solver/core/traits.rs
@@ -212,6 +212,11 @@ where
     /// restore a prior iterate
     fn reset_to_prev_iterate(&mut self, variables: &mut Self::V, prev_variables: &Self::V);
 
+    /// save the current iterate as the best seen so far if it improves on it
+    fn save_best_iterate(&mut self, variables: &Self::V, best_variables: &mut Self::V);
+    /// restore the best iterate seen if it improves on the current one
+    fn reset_to_best_iterate(&mut self, variables: &mut Self::V, best_variables: &Self::V);
+
     /// Record some of the top level solver's choice of various
     /// scalars. `μ = ` normalized gap.  `α = ` computed step length.
     /// `σ = ` multiplier for the updated centering parameter.

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -446,3 +446,76 @@ where
             && (self.res_dual_inf < -tol_infeas_rel * residuals.dot_qx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solver::core::traits::Info;
+
+    // fabricate an iterate whose merit-relevant fields are set directly, with x[0]
+    // tagging which iterate it is so we can see which one survives
+    fn set_iterate(info: &mut DefaultInfo<f64>, vars: &mut DefaultVariables<f64>, res: f64, ktratio: f64, tag: f64) {
+        info.res_primal = res;
+        info.res_dual = res;
+        info.gap_rel = res;
+        info.gap_abs = res;
+        info.ktratio = ktratio;
+        vars.x[0] = tag;
+    }
+
+    #[test]
+    fn best_iterate_survives_a_degraded_final_iterate() {
+        let mut info = DefaultInfo::<f64>::new();
+        let mut vars = DefaultVariables::<f64>::new(1, 1);
+        let mut best = DefaultVariables::<f64>::new(1, 1);
+        info.reset(&mut Default::default());
+
+        // a good iterate, then a better one, then the blowup that ends the solve
+        set_iterate(&mut info, &mut vars, 1e-6, 0.5, 1.0);
+        info.save_best_iterate(&vars, &mut best);
+        set_iterate(&mut info, &mut vars, 1e-10, 0.5, 2.0);
+        info.save_best_iterate(&vars, &mut best);
+        set_iterate(&mut info, &mut vars, 3e-5, 0.5, 3.0);
+        info.save_best_iterate(&vars, &mut best);
+
+        info.reset_to_best_iterate(&mut vars, &best);
+
+        assert_eq!(vars.x[0], 2.0, "the 1e-10 iterate should be restored");
+        assert_eq!(info.res_primal, 1e-10);
+        assert_eq!(info.gap_rel, 1e-10);
+    }
+
+    #[test]
+    fn a_better_final_iterate_is_left_alone() {
+        let mut info = DefaultInfo::<f64>::new();
+        let mut vars = DefaultVariables::<f64>::new(1, 1);
+        let mut best = DefaultVariables::<f64>::new(1, 1);
+        info.reset(&mut Default::default());
+
+        set_iterate(&mut info, &mut vars, 1e-6, 0.5, 1.0);
+        info.save_best_iterate(&vars, &mut best);
+        set_iterate(&mut info, &mut vars, 1e-9, 0.5, 2.0);
+
+        info.reset_to_best_iterate(&mut vars, &best);
+
+        assert_eq!(vars.x[0], 2.0, "the current iterate is the best one; keep it");
+        assert_eq!(info.res_primal, 1e-9);
+    }
+
+    #[test]
+    fn iterates_on_the_infeasibility_path_are_not_candidates() {
+        let mut info = DefaultInfo::<f64>::new();
+        let mut vars = DefaultVariables::<f64>::new(1, 1);
+        let mut best = DefaultVariables::<f64>::new(1, 1);
+        info.reset(&mut Default::default());
+
+        // tiny residuals but ktratio > 1: this is an infeasibility certificate path
+        set_iterate(&mut info, &mut vars, 1e-12, 5.0, 1.0);
+        info.save_best_iterate(&vars, &mut best);
+        set_iterate(&mut info, &mut vars, 3e-5, 5.0, 2.0);
+        info.reset_to_best_iterate(&mut vars, &best);
+
+        assert_eq!(vars.x[0], 2.0, "nothing was ever saved, so nothing is restored");
+        assert!(!info.best_merit.is_finite());
+    }
+}

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -51,6 +51,18 @@ pub struct DefaultInfo<T> {
     pub(crate) prev_gap_abs: T,
     /// relative duality gap from previous iteration
     pub(crate) prev_gap_rel: T,
+
+    // best iterate seen so far (by worst-case residual/gap merit), used as a
+    // fallback when the solver terminates with a numerical error on a
+    // degraded final iterate
+    pub(crate) best_cost_primal: T,
+    pub(crate) best_cost_dual: T,
+    pub(crate) best_res_primal: T,
+    pub(crate) best_res_dual: T,
+    pub(crate) best_gap_abs: T,
+    pub(crate) best_gap_rel: T,
+    pub(crate) best_ktratio: T,
+    pub(crate) best_merit: T,
     /// solve time
     pub solve_time: f64,
     /// solver status
@@ -88,6 +100,7 @@ where
         self.status = SolverStatus::Unsolved;
         self.iterations = 0;
         self.solve_time = 0f64;
+        self.best_merit = T::infinity();
 
         timers.reset_timer("solve");
     }
@@ -250,6 +263,51 @@ where
         self.gap_rel = self.prev_gap_rel;
 
         variables.copy_from(prev_variables);
+    }
+
+    fn save_best_iterate(&mut self, variables: &Self::V, best_variables: &mut Self::V) {
+        // Merit is the worst of the quantities the (almost-)solved checks test. Iterates on
+        // an infeasibility path (κ/τ > 1) are never candidates.
+        if self.ktratio > T::one() {
+            return;
+        }
+
+        let merit = T::max(T::max(self.gap_rel, self.res_primal), self.res_dual);
+        if merit >= self.best_merit {
+            return;
+        }
+
+        self.best_merit = merit;
+        self.best_cost_primal = self.cost_primal;
+        self.best_cost_dual = self.cost_dual;
+        self.best_res_primal = self.res_primal;
+        self.best_res_dual = self.res_dual;
+        self.best_gap_abs = self.gap_abs;
+        self.best_gap_rel = self.gap_rel;
+        self.best_ktratio = self.ktratio;
+
+        best_variables.copy_from(variables);
+    }
+
+    fn reset_to_best_iterate(&mut self, variables: &mut Self::V, best_variables: &Self::V) {
+        if !self.best_merit.is_finite() {
+            return;
+        }
+
+        let merit = T::max(T::max(self.gap_rel, self.res_primal), self.res_dual);
+        if self.ktratio <= T::one() && merit <= self.best_merit {
+            return;
+        }
+
+        self.cost_primal = self.best_cost_primal;
+        self.cost_dual = self.best_cost_dual;
+        self.res_primal = self.best_res_primal;
+        self.res_dual = self.best_res_dual;
+        self.gap_abs = self.best_gap_abs;
+        self.gap_rel = self.best_gap_rel;
+        self.ktratio = self.best_ktratio;
+
+        variables.copy_from(best_variables);
     }
 
     fn save_scalars(&mut self, μ: T, α: T, σ: T, iter: u32) {

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -276,8 +276,15 @@ where
             return;
         }
 
+        // Strict improvement, tested so that a non-finite merit is rejected.  Every
+        // comparison against NaN is false, so `merit >= best_merit` would treat a NaN
+        // iterate as an improvement, overwrite a good one with it, and then disable the
+        // fallback altogether, since the restore below requires a finite best_merit --
+        // and a solve whose iterates have gone non-finite is exactly the case this is
+        // meant to rescue.  The same test rejects an infinite merit, which is what a
+        // zero reduced tolerance would produce.
         let merit = self.termination_merit(settings);
-        if merit >= self.best_merit {
+        if !(merit < self.best_merit) {
             return;
         }
 
@@ -602,6 +609,34 @@ mod tests {
         info.reset_to_best_iterate(&mut vars, &best, &settings);
         assert_eq!(vars.x[0], 2.0);
         assert_eq!(info.res_primal, 9e-5);
+    }
+
+    // A solve whose iterates go non-finite is the case this fallback exists for, so a NaN
+    // iterate must not be able to displace the good one that preceded it.  Comparisons
+    // against NaN are all false, which makes this easy to get wrong.
+    #[test]
+    fn a_nan_iterate_cannot_displace_the_best_one() {
+        let settings = DefaultSettings::<f64>::default();
+        let mut info = DefaultInfo::<f64>::new();
+        let mut vars = DefaultVariables::<f64>::new(1, 1);
+        let mut best = DefaultVariables::<f64>::new(1, 1);
+        info.reset(&mut Default::default());
+
+        set_iterate(&mut info, &mut vars, 1e-10, 0.5, 1.0);
+        info.save_best_iterate(&vars, &mut best, &settings);
+
+        // the solve blows up: residuals, gap and κ/τ are all NaN
+        set_iterate(&mut info, &mut vars, f64::NAN, f64::NAN, 2.0);
+        info.save_best_iterate(&vars, &mut best, &settings);
+        assert_eq!(best.x[0], 1.0, "the NaN iterate must not be saved");
+        assert!(
+            info.best_merit.is_finite(),
+            "the fallback must remain armed"
+        );
+
+        info.reset_to_best_iterate(&mut vars, &best, &settings);
+        assert_eq!(vars.x[0], 1.0, "the good iterate must be restored");
+        assert_eq!(info.res_primal, 1e-10);
     }
 
     #[test]

--- a/src/solver/implementations/default/info.rs
+++ b/src/solver/implementations/default/info.rs
@@ -265,14 +265,18 @@ where
         variables.copy_from(prev_variables);
     }
 
-    fn save_best_iterate(&mut self, variables: &Self::V, best_variables: &mut Self::V) {
-        // Merit is the worst of the quantities the (almost-)solved checks test. Iterates on
-        // an infeasibility path (κ/τ > 1) are never candidates.
+    fn save_best_iterate(
+        &mut self,
+        variables: &Self::V,
+        best_variables: &mut Self::V,
+        settings: &DefaultSettings<T>,
+    ) {
+        // Iterates on an infeasibility path (κ/τ > 1) are never candidates.
         if self.ktratio > T::one() {
             return;
         }
 
-        let merit = T::max(T::max(self.gap_rel, self.res_primal), self.res_dual);
+        let merit = self.termination_merit(settings);
         if merit >= self.best_merit {
             return;
         }
@@ -289,12 +293,17 @@ where
         best_variables.copy_from(variables);
     }
 
-    fn reset_to_best_iterate(&mut self, variables: &mut Self::V, best_variables: &Self::V) {
+    fn reset_to_best_iterate(
+        &mut self,
+        variables: &mut Self::V,
+        best_variables: &Self::V,
+        settings: &DefaultSettings<T>,
+    ) {
         if !self.best_merit.is_finite() {
             return;
         }
 
-        let merit = T::max(T::max(self.gap_rel, self.res_primal), self.res_dual);
+        let merit = self.termination_merit(settings);
         if self.ktratio <= T::one() && merit <= self.best_merit {
             return;
         }
@@ -420,6 +429,32 @@ where
         }
     }
 
+    // How far the current iterate is from satisfying `is_solved` at the *reduced*
+    // tolerances: each quantity divided by the tolerance that will judge it, combined
+    // exactly as in that test, so the duality gap enters through whichever of its
+    // absolute/relative forms is closer to passing.  A merit below 1 passes.
+    //
+    // The reduced tolerances are the right yardstick because this merit only ever ranks
+    // candidates for an unsuccessful exit, where `check_convergence_almost` -- which uses
+    // exactly these tolerances -- decides whether the restored iterate can still be
+    // reported as AlmostSolved.  Ranking by them makes the selection safe: the chosen
+    // iterate has the smallest reduced merit of all candidates, so if any candidate would
+    // have passed that check, the chosen one passes it too.  Comparing the raw quantities
+    // instead can prefer an iterate that fails the check over one that passes, because the
+    // tolerances differ from each other -- by default `reduced_tol_feas` is 1e-4 while
+    // `reduced_tol_gap_rel` is 5e-5.
+    fn termination_merit(&self, settings: &DefaultSettings<T>) -> T {
+        let gap = T::min(
+            self.gap_abs / settings.reduced_tol_gap_abs,
+            self.gap_rel / settings.reduced_tol_gap_rel,
+        );
+        let feas = T::max(
+            self.res_primal / settings.reduced_tol_feas,
+            self.res_dual / settings.reduced_tol_feas,
+        );
+        T::max(gap, feas)
+    }
+
     fn is_solved(&self, tol_gap_abs: T, tol_gap_rel: T, tol_feas: T) -> bool {
         ((self.gap_abs < tol_gap_abs) || (self.gap_rel < tol_gap_rel))
             && (self.res_primal < tol_feas)
@@ -454,7 +489,13 @@ mod tests {
 
     // fabricate an iterate whose merit-relevant fields are set directly, with x[0]
     // tagging which iterate it is so we can see which one survives
-    fn set_iterate(info: &mut DefaultInfo<f64>, vars: &mut DefaultVariables<f64>, res: f64, ktratio: f64, tag: f64) {
+    fn set_iterate(
+        info: &mut DefaultInfo<f64>,
+        vars: &mut DefaultVariables<f64>,
+        res: f64,
+        ktratio: f64,
+        tag: f64,
+    ) {
         info.res_primal = res;
         info.res_dual = res;
         info.gap_rel = res;
@@ -465,6 +506,7 @@ mod tests {
 
     #[test]
     fn best_iterate_survives_a_degraded_final_iterate() {
+        let settings = DefaultSettings::<f64>::default();
         let mut info = DefaultInfo::<f64>::new();
         let mut vars = DefaultVariables::<f64>::new(1, 1);
         let mut best = DefaultVariables::<f64>::new(1, 1);
@@ -472,13 +514,13 @@ mod tests {
 
         // a good iterate, then a better one, then the blowup that ends the solve
         set_iterate(&mut info, &mut vars, 1e-6, 0.5, 1.0);
-        info.save_best_iterate(&vars, &mut best);
+        info.save_best_iterate(&vars, &mut best, &settings);
         set_iterate(&mut info, &mut vars, 1e-10, 0.5, 2.0);
-        info.save_best_iterate(&vars, &mut best);
+        info.save_best_iterate(&vars, &mut best, &settings);
         set_iterate(&mut info, &mut vars, 3e-5, 0.5, 3.0);
-        info.save_best_iterate(&vars, &mut best);
+        info.save_best_iterate(&vars, &mut best, &settings);
 
-        info.reset_to_best_iterate(&mut vars, &best);
+        info.reset_to_best_iterate(&mut vars, &best, &settings);
 
         assert_eq!(vars.x[0], 2.0, "the 1e-10 iterate should be restored");
         assert_eq!(info.res_primal, 1e-10);
@@ -487,23 +529,84 @@ mod tests {
 
     #[test]
     fn a_better_final_iterate_is_left_alone() {
+        let settings = DefaultSettings::<f64>::default();
         let mut info = DefaultInfo::<f64>::new();
         let mut vars = DefaultVariables::<f64>::new(1, 1);
         let mut best = DefaultVariables::<f64>::new(1, 1);
         info.reset(&mut Default::default());
 
         set_iterate(&mut info, &mut vars, 1e-6, 0.5, 1.0);
-        info.save_best_iterate(&vars, &mut best);
+        info.save_best_iterate(&vars, &mut best, &settings);
         set_iterate(&mut info, &mut vars, 1e-9, 0.5, 2.0);
 
-        info.reset_to_best_iterate(&mut vars, &best);
+        info.reset_to_best_iterate(&mut vars, &best, &settings);
 
-        assert_eq!(vars.x[0], 2.0, "the current iterate is the best one; keep it");
+        assert_eq!(
+            vars.x[0], 2.0,
+            "the current iterate is the best one; keep it"
+        );
         assert_eq!(info.res_primal, 1e-9);
+    }
+
+    // The acceptance check applied on an unsuccessful exit uses a different tolerance for
+    // each quantity -- by default reduced_tol_feas is 1e-4 but reduced_tol_gap_rel is 5e-5 --
+    // so ranking candidates by the raw worst quantity can prefer one that fails the check
+    // over one that passes it.  Here the first candidate has the smaller raw maximum (8e-5
+    // against 9e-5) yet its gap is outside tolerance, while the second is inside on every
+    // count; the second must be the one restored.
+    #[test]
+    fn merit_ranks_by_distance_from_the_acceptance_check() {
+        let settings = DefaultSettings::<f64>::default();
+        let mut info = DefaultInfo::<f64>::new();
+        let mut vars = DefaultVariables::<f64>::new(1, 1);
+        let mut best = DefaultVariables::<f64>::new(1, 1);
+        info.reset(&mut Default::default());
+
+        // candidate 1: gap outside the reduced tolerance, residuals well inside
+        info.gap_abs = 8e-5;
+        info.gap_rel = 8e-5;
+        info.res_primal = 1e-5;
+        info.res_dual = 1e-5;
+        info.ktratio = 0.5;
+        vars.x[0] = 1.0;
+        info.save_best_iterate(&vars, &mut best, &settings);
+        assert!(!info.is_solved(
+            settings.reduced_tol_gap_abs,
+            settings.reduced_tol_gap_rel,
+            settings.reduced_tol_feas
+        ));
+
+        // candidate 2: larger raw maximum, but inside tolerance on every count
+        info.gap_abs = 2e-5;
+        info.gap_rel = 2e-5;
+        info.res_primal = 9e-5;
+        info.res_dual = 9e-5;
+        vars.x[0] = 2.0;
+        info.save_best_iterate(&vars, &mut best, &settings);
+        assert!(info.is_solved(
+            settings.reduced_tol_gap_abs,
+            settings.reduced_tol_gap_rel,
+            settings.reduced_tol_feas
+        ));
+        assert_eq!(
+            best.x[0], 2.0,
+            "the iterate that passes the check must be preferred"
+        );
+
+        // and it is the one a degraded final iterate is replaced by
+        info.gap_abs = 1e-2;
+        info.gap_rel = 1e-2;
+        info.res_primal = 1e-2;
+        info.res_dual = 1e-2;
+        vars.x[0] = 3.0;
+        info.reset_to_best_iterate(&mut vars, &best, &settings);
+        assert_eq!(vars.x[0], 2.0);
+        assert_eq!(info.res_primal, 9e-5);
     }
 
     #[test]
     fn iterates_on_the_infeasibility_path_are_not_candidates() {
+        let settings = DefaultSettings::<f64>::default();
         let mut info = DefaultInfo::<f64>::new();
         let mut vars = DefaultVariables::<f64>::new(1, 1);
         let mut best = DefaultVariables::<f64>::new(1, 1);
@@ -511,11 +614,14 @@ mod tests {
 
         // tiny residuals but ktratio > 1: this is an infeasibility certificate path
         set_iterate(&mut info, &mut vars, 1e-12, 5.0, 1.0);
-        info.save_best_iterate(&vars, &mut best);
+        info.save_best_iterate(&vars, &mut best, &settings);
         set_iterate(&mut info, &mut vars, 3e-5, 5.0, 2.0);
-        info.reset_to_best_iterate(&mut vars, &best);
+        info.reset_to_best_iterate(&mut vars, &best, &settings);
 
-        assert_eq!(vars.x[0], 2.0, "nothing was ever saved, so nothing is restored");
+        assert_eq!(
+            vars.x[0], 2.0,
+            "nothing was ever saved, so nothing is restored"
+        );
         assert!(!info.best_merit.is_finite());
     }
 }

--- a/src/solver/implementations/default/solver.rs
+++ b/src/solver/implementations/default/solver.rs
@@ -105,12 +105,13 @@ where
         let step_rhs  = DefaultVariables::<T>::new(data.n,data.m);
         let step_lhs  = DefaultVariables::<T>::new(data.n,data.m);
         let prev_vars = DefaultVariables::<T>::new(data.n,data.m);
+        let best_vars = DefaultVariables::<T>::new(data.n,data.m);
 
         // configure empty user callbacks
 
         output = Self{
             data,variables,residuals,kktsystem,
-            step_lhs,step_rhs,prev_vars,info,
+            step_lhs,step_rhs,prev_vars,best_vars,info,
             solution,cones,settings,
             timers: None,
             callbacks: SolverCallbacks::default(),


### PR DESCRIPTION
## The bug

When the interior-point loop terminates with `NumericalError` or `InsufficientProgress`, the reduced-tolerance ("almost solved") acceptance check is evaluated against the **final** iterate. But on a numerical failure the final iterate is typically the one that just went bad -- that is *why* the solver stopped. The good iterate from one step earlier is discarded, and the solve is reported as a failure on the strength of a point the solver had already superseded.

This shows up on problems whose attainable gap floor sits close to the requested tolerance: the primal residual jumps from ~1e-10 to ~3e-5 in a single step, the loop bails out, and the almost-solved test is then applied to the ruined point and fails. The solver had a perfectly acceptable answer in hand and threw it away.

## The fix

Track the best iterate seen so far and restore it before the almost-solved check runs.

- **Merit** is the iterate's distance from passing `is_solved` at the *reduced* tolerances: each quantity divided by the tolerance that will judge it, combined exactly as in that test, so the duality gap enters through whichever of its absolute or relative forms is closer to passing. Those are the tolerances `check_convergence_almost` applies to the restored iterate, so ranking by them makes the choice safe rather than merely reasonable: the selected iterate has the smallest reduced merit of all candidates, so **if any candidate would have passed that check, the selected one passes it too**. Comparing the raw quantities instead can prefer an iterate that fails the check over one that passes it, because the tolerances differ from each other -- by default `reduced_tol_feas` is 1e-4 while `reduced_tol_gap_rel` is 5e-5.
- Iterates with `ktratio > 1` are **never** candidates: those lie on the infeasibility-certificate path and must not be presented as approximate solutions.
- A **non-finite merit is never an improvement.** Every comparison against NaN is false, so a naive `merit >= best` test would let a NaN iterate be stored as the best one and, because the restore requires a finite best merit, silently disarm the fallback for the rest of the solve -- on exactly the solves it exists to rescue. Testing strict improvement rejects it, and also rejects the infinite merit a reduced tolerance of zero would produce.
- The restore is a no-op when the final iterate is already the best one, so the path is inert on every solve that terminates `Solved`.
- It fires on `MaxIterations` and `MaxTime` as well as the error statuses, because `post_process` runs the same acceptance check for those exits and their final iterate is no more likely to be the best one seen.

Cost is one extra `DefaultVariables` and a copy on strict improvement.

## Evidence

**It only ever helps.** Verified against stock on 224 public problems (101 Maros-Meszaros QPs, 85 Netlib LPs, 24 structured conic, 12 Netlib-Kennington, 2 Mittelmann): **no status changes and no iteration-count changes**, and a single objective difference, on `mm_yao`, which terminates `AlmostSolved` in both and returns its better iterate. That is the expected result -- problems that terminate normally never reach the restore -- and it bounds the blast radius: the patch cannot regress a solve that was already succeeding.

Two further suites, used only as gates: **45 MIPLIB 2017 benchmark instances as LP relaxations** and **84 CBLIB instances**. No status changes and no objective disagreements above 1e-6 on either, and timing unchanged throughout (-0.1% and -0.0%, i.e. noise), as expected for a path that is inert unless a solve fails.

Two of those MIPLIB relaxations, `brazil3` and `comp07_2idx`, are the cases most sensitive to how the merit is defined; both return objectives identical to stock (1.9999982324 and 1.5433363423e-9).

## Tests

Five unit tests cover the semantics: a degraded final iterate is discarded in favour of the best seen; a final iterate that is itself the best is left untouched; iterates on the infeasibility path are never eligible to be saved or restored; the merit ranks by distance from the acceptance check rather than by raw magnitude, encoding a case where the raw comparison would prefer an iterate that fails the check over one that passes; and a NaN iterate cannot displace the best one or disarm the fallback. The last two were each checked to fail against the code they replaced, so they test what they claim to.

Full suite green: `cargo test`, 20 test binaries, 0 failures.
