### PR TITLE
qdldl: form KKT refinement residuals from a both-triangles matrix copy

### DIFF
--- a/src/qdldl/qdldl.rs
+++ b/src/qdldl/qdldl.rs
@@ -87,6 +87,11 @@ pub struct QDLDLFactorisation<T = f64> {
     is_symbolic: bool,
     /// workspace for `solve_refined`, allocated on first use
     ir_work: Option<RefinementWorkspace<T>>,
+    /// both-triangles copy of the internal matrix, for refinement
+    /// residuals; built on first use and refreshed when values change
+    sym: Option<SymmetricCopy<T>>,
+    /// true when `sym`'s values are stale w.r.t. the internal matrix
+    sym_stale: bool,
 }
 
 // working vectors for solve_refined, all in permuted coordinates
@@ -95,6 +100,153 @@ struct RefinementWorkspace<T> {
     x: Vec<T>,  // current solution
     dx: Vec<T>, // refinement step / trial solution
     e: Vec<T>,  // residual
+}
+
+// A full (both triangles) copy of the internally permuted matrix.
+//
+// Refinement residuals `e = b - Ax` were computed from the upper triangle
+// alone, which requires exploiting symmetry with two scattered
+// read-modify-writes per off-diagonal nonzero (into `y[row]` and
+// `y[col]`).   Holding both triangles instead costs about twice the memory
+// but removes the scatter entirely: because A is symmetric, its CSC arrays
+// read as CSR describe the same matrix, so row i of A is exactly what is
+// stored as "column i".   The residual is then a sequence of independent
+// sparse dot products -- one contiguous pass over the values, gathered
+// reads of x, and an accumulator in a register.
+//
+// `sym_to_triu` gives, for each nonzero here, the index of the
+// upper-triangular source entry it takes its value from: an off-diagonal
+// source is referenced twice (once per triangle), a diagonal source once.
+// Mapping this direction rather than source-to-destination makes the value
+// refresh a gather with sequential stores instead of a scatter.
+#[derive(Debug)]
+struct SymmetricCopy<T> {
+    A: CscMatrix<T>,
+    sym_to_triu: Vec<u32>,
+}
+
+// Builds the both-triangles copy and the value map from an upper
+// triangular source.   Returns None if the pattern is too large for the
+// u32 index map, in which case refinement falls back to the triangular
+// symmetric matrix-vector product.
+fn _build_symmetric_copy<T: FloatT>(triu: &CscMatrix<T>) -> Option<SymmetricCopy<T>> {
+    let n = triu.ncols();
+    let nnz_triu = triu.nzval.len();
+    let mut ndiag = 0;
+    for j in 0..n {
+        for &i in &triu.rowval[triu.colptr[j]..triu.colptr[j + 1]] {
+            if i == j {
+                ndiag += 1;
+            }
+        }
+    }
+    let nnz_sym = 2 * nnz_triu - ndiag;
+    if nnz_sym >= u32::MAX as usize {
+        return None;
+    }
+
+    // column counts: entry (i,j), i <= j, lands in column j and, when
+    // off-diagonal, also in column i
+    let mut colptr = vec![0usize; n + 1];
+    for j in 0..n {
+        for &i in &triu.rowval[triu.colptr[j]..triu.colptr[j + 1]] {
+            colptr[j + 1] += 1;
+            if i != j {
+                colptr[i + 1] += 1;
+            }
+        }
+    }
+    for j in 0..n {
+        colptr[j + 1] += colptr[j];
+    }
+
+    let mut rowval = vec![0usize; nnz_sym];
+    let mut next = colptr[0..n].to_vec();
+    let mut sym_to_triu = vec![0u32; nnz_sym];
+    for j in 0..n {
+        let base = triu.colptr[j];
+        for (t, &i) in triu.rowval[base..triu.colptr[j + 1]].iter().enumerate() {
+            let k = base + t;
+            let pj = next[j];
+            rowval[pj] = i;
+            sym_to_triu[pj] = k as u32;
+            next[j] += 1;
+            if i != j {
+                let pi = next[i];
+                rowval[pi] = j;
+                sym_to_triu[pi] = k as u32;
+                next[i] += 1;
+            }
+        }
+    }
+
+    let A = CscMatrix {
+        m: n,
+        n,
+        colptr,
+        rowval,
+        nzval: vec![T::zero(); nnz_sym],
+    };
+    Some(SymmetricCopy { A, sym_to_triu })
+}
+
+// Computes e = b - Ax for symmetric A held in both-triangles form,
+// reading its CSC arrays as CSR (valid because A = Aᵀ), and returns
+// ||e||_∞.   Each row is an independent sparse dot product.
+//
+// The loop is memory bound -- one streamed value and one gathered x per
+// nonzero -- so the accumulators stay in registers.  Four are used and
+// reduced pairwise.   A single accumulator serializes each row on the
+// latency of one dependent add, and independent partial sums also carry a
+// tighter error bound than sequential summation, growing like n/k + k for
+// k accumulators rather than n (Higham, "Accuracy and Stability of
+// Numerical Algorithms", 2nd ed., 2002, §4.2, on blocked and pairwise
+// summation).
+//
+// Four rather than two or eight, measured on the portfolio problems:
+// one accumulator is ~8% slower than four; two is ~1% *faster* than four
+// but degrades one problem from AlmostSolved to InsufficientProgress,
+// consistent with its looser summation error; eight is indistinguishable
+// from four in time and needs more code.   Four is therefore the smallest
+// count that captures both the pipelining and the accuracy.
+fn _sym_residual<T: FloatT>(sym: &SymmetricCopy<T>, e: &mut [T], b: &[T], x: &[T]) -> T {
+    let (colptr, rowval, nzval) = (&sym.A.colptr, &sym.A.rowval, &sym.A.nzval);
+    let mut norme = T::zero();
+    // A NaN residual must be reported, and cannot be detected by the
+    // running maximum alone: IEEE maxNum returns the non-NaN operand, so a
+    // NaN would leave `norme` finite and let a non-finite solution be
+    // accepted as converged.   Tracked separately and folded in at the end.
+    let mut any_nan = false;
+    for (i, ei) in e.iter_mut().enumerate() {
+        let (f, l) = (colptr[i], colptr[i + 1]);
+        let (vals, cols) = (&nzval[f..l], &rowval[f..l]);
+        let nchunk = vals.len() / 4;
+
+        let mut s = [T::zero(); 4];
+        unsafe {
+            // Safety: rowval entries are column indices of a matrix with
+            // the same dimension as x, as built by _build_symmetric_copy.
+            for c in 0..nchunk {
+                let (v, k) = (&vals[4 * c..4 * c + 4], &cols[4 * c..4 * c + 4]);
+                s[0] += v[0] * *x.get_unchecked(k[0]);
+                s[1] += v[1] * *x.get_unchecked(k[1]);
+                s[2] += v[2] * *x.get_unchecked(k[2]);
+                s[3] += v[3] * *x.get_unchecked(k[3]);
+            }
+            for t in 4 * nchunk..vals.len() {
+                s[t & 3] += vals[t] * *x.get_unchecked(cols[t]);
+            }
+        }
+
+        let ri = b[i] - ((s[0] + s[1]) + (s[2] + s[3]));
+        *ei = ri;
+        any_nan |= ri.is_nan();
+        norme = T::max(norme, T::abs(ri));
+    }
+    if any_nan {
+        return T::nan();
+    }
+    norme
 }
 
 impl<T> QDLDLFactorisation<T>
@@ -178,6 +330,23 @@ where
         assert_eq!(x.len(), self.D.len());
 
         let n = self.D.len();
+
+        // build the both-triangles copy on first use, and refresh its
+        // values whenever the internal matrix has been modified since
+        if self.sym.is_none() {
+            self.sym = _build_symmetric_copy(&self.workspace.triuA);
+            self.sym_stale = true;
+        }
+        if self.sym_stale {
+            if let Some(sym) = &mut self.sym {
+                let src = &self.workspace.triuA.nzval;
+                for (dst, &k) in zip(&mut sym.A.nzval, &sym.sym_to_triu) {
+                    *dst = src[k as usize];
+                }
+            }
+            self.sym_stale = false;
+        }
+
         let work = self.ir_work.get_or_insert_with(|| RefinementWorkspace {
             x: vec![T::zero(); n],
             dx: vec![T::zero(); n],
@@ -197,11 +366,19 @@ where
         xp.copy_from(bp);
         _solve(Lp, Li, Lx, &self.Dinv, xp);
 
-        // computes e = bp - A*ξ and returns its norm
+        // computes e = bp - A*ξ and returns its norm.  Prefers the
+        // both-triangles copy (a pure gather; see `SymmetricCopy`), and
+        // falls back to the triangular symv if that copy is unavailable.
+        let sym = self.sym.as_ref();
         let refine_error = |e: &mut [T], ξ: &[T]| -> T {
-            e.copy_from(bp);
-            Asym.symv(e, ξ, -T::one(), T::one());
-            e.norm_inf()
+            match sym {
+                Some(sym) => _sym_residual(sym, e, bp, ξ),
+                None => {
+                    e.copy_from(bp);
+                    Asym.symv(e, ξ, -T::one(), T::one());
+                    e.norm_inf()
+                }
+            }
         };
 
         let (e, dx) = (&mut work.e, &mut work.dx);
@@ -246,6 +423,7 @@ where
     /// Update a subset of the values of the matrix to be (re)factored.  See [`refactor`](crate::qdldl::QDLDLFactorisation::refactor)
     ///
     pub fn update_values(&mut self, indices: &[usize], values: &[T]) {
+        self.sym_stale = true;
         let nzval = &mut self.workspace.triuA.nzval; // post perm internal data
         let AtoPAPt = &self.workspace.AtoPAPt; //mapping from input matrix entries to triuA
 
@@ -257,6 +435,7 @@ where
     /// Update a subset of the values of the matrix to be (re)factored.  See [`refactor`](crate::qdldl::QDLDLFactorisation::refactor)
     ///
     pub fn scale_values(&mut self, indices: &[usize], scale: T) {
+        self.sym_stale = true;
         let nzval = &mut self.workspace.triuA.nzval; // post perm internal data
         let AtoPAPt = &self.workspace.AtoPAPt; //mapping from input matrix entries to triuA
 
@@ -270,6 +449,7 @@ where
     /// indicating the direction of shifts. See [`refactor`](crate::qdldl::QDLDLFactorisation::refactor)
     ///
     pub fn offset_values(&mut self, indices: &[usize], offset: T, signs: &[i8]) {
+        self.sym_stale = true;
         assert_eq!(indices.len(), signs.len());
 
         let nzval = &mut self.workspace.triuA.nzval; // post perm internal data
@@ -398,6 +578,8 @@ fn _qdldl_new<T: FloatT>(
         workspace,
         is_symbolic: opts.logical,
         ir_work: None,
+        sym: None,
+        sym_stale: true,
     })
 }
 

--- a/src/qdldl/qdldl.rs
+++ b/src/qdldl/qdldl.rs
@@ -85,6 +85,16 @@ pub struct QDLDLFactorisation<T = f64> {
     workspace: QDLDLWorkspace<T>,
     /// true if factorisation is symbolic only
     is_symbolic: bool,
+    /// workspace for `solve_refined`, allocated on first use
+    ir_work: Option<RefinementWorkspace<T>>,
+}
+
+// working vectors for solve_refined, all in permuted coordinates
+#[derive(Debug)]
+struct RefinementWorkspace<T> {
+    x: Vec<T>,  // current solution
+    dx: Vec<T>, // refinement step / trial solution
+    e: Vec<T>,  // residual
 }
 
 impl<T> QDLDLFactorisation<T>
@@ -135,6 +145,102 @@ where
 
         // inverse permutation to put unpermuted soln in b
         ipermute(b, tmp, &self.perm);
+    }
+
+    /// Solves Ax = b like [`solve`](crate::qdldl::QDLDLFactorisation::solve),
+    /// then iteratively refines x against the matrix currently held in the
+    /// internal workspace (i.e. the values set through
+    /// [`update_values`](crate::qdldl::QDLDLFactorisation::update_values) and
+    /// friends, which may deliberately differ from the values that were
+    /// factored, e.g. by a static regularization shift).
+    ///
+    /// The refinement loop runs entirely in the internally permuted
+    /// coordinates: the permutation is applied once to `b` and once to the
+    /// returned `x`, rather than once per backsolve as with repeated calls
+    /// to [`solve`](crate::qdldl::QDLDLFactorisation::solve).  Stopping
+    /// rules: refinement ends when the residual satisfies
+    /// `norm(b - Ax) <= abstol + reltol * norm(b)` (∞-norms), when
+    /// `max_iter` passes have been made, or when a pass fails to improve
+    /// the residual norm by at least `stop_ratio` (an improving final pass
+    /// is still accepted).  Returns false if the solution or residual
+    /// became non-finite.
+    pub fn solve_refined(
+        &mut self,
+        x: &mut [T],
+        b: &[T],
+        reltol: T,
+        abstol: T,
+        max_iter: u32,
+        stop_ratio: T,
+    ) -> bool {
+        assert!(!self.is_symbolic);
+        assert_eq!(b.len(), self.D.len());
+        assert_eq!(x.len(), self.D.len());
+
+        let n = self.D.len();
+        let work = self.ir_work.get_or_insert_with(|| RefinementWorkspace {
+            x: vec![T::zero(); n],
+            dx: vec![T::zero(); n],
+            e: vec![T::zero(); n],
+        });
+
+        // permute b once; all work below is in permuted coordinates
+        let bp = &mut self.workspace.fwork;
+        permute(bp, b, &self.perm);
+
+        let (Lp, Li, Lx) = (&self.L.colptr, &self.L.rowval, &self.L.nzval);
+        let Asym = self.workspace.triuA.sym_up();
+        let normb = bp.norm_inf();
+
+        // initial solve
+        let xp = &mut work.x;
+        xp.copy_from(bp);
+        _solve(Lp, Li, Lx, &self.Dinv, xp);
+
+        // computes e = bp - A*ξ and returns its norm
+        let refine_error = |e: &mut [T], ξ: &[T]| -> T {
+            e.copy_from(bp);
+            Asym.symv(e, ξ, -T::one(), T::one());
+            e.norm_inf()
+        };
+
+        let (e, dx) = (&mut work.e, &mut work.dx);
+        let mut norme = refine_error(e, xp);
+        if !norme.is_finite() {
+            return false;
+        }
+
+        for _ in 0..max_iter {
+            if norme <= (abstol + reltol * normb) {
+                // within tolerance.  Exit
+                break;
+            }
+            let lastnorme = norme;
+
+            // make a refinement: dx = A⁻¹e, prospective solution xp + dx
+            dx.copy_from(e);
+            _solve(Lp, Li, Lx, &self.Dinv, dx);
+            dx.axpby(T::one(), xp, T::one());
+
+            norme = refine_error(e, dx);
+            if !norme.is_finite() {
+                return false;
+            }
+
+            let improved_ratio = lastnorme / norme;
+            if improved_ratio < stop_ratio {
+                // insufficient improvement.  Exit
+                if improved_ratio > T::one() {
+                    std::mem::swap(xp, dx);
+                }
+                break;
+            }
+            std::mem::swap(xp, dx);
+        }
+
+        // undo the permutation into the output
+        ipermute(x, xp, &self.perm);
+        true
     }
 
     /// Update a subset of the values of the matrix to be (re)factored.  See [`refactor`](crate::qdldl::QDLDLFactorisation::refactor)
@@ -291,6 +397,7 @@ fn _qdldl_new<T: FloatT>(
         Dinv,
         workspace,
         is_symbolic: opts.logical,
+        ir_work: None,
     })
 }
 

--- a/src/qdldl/test.rs
+++ b/src/qdldl/test.rs
@@ -20,6 +20,10 @@ fn test_matrix_4x4() -> CscMatrix<f64> {
     }
 }
 
+fn inf_norm<T: FloatT>(a: &[T]) -> T {
+    a.iter().fold(T::zero(), |acc, x| T::max(acc, T::abs(*x)))
+}
+
 fn inf_norm_diff<T: FloatT>(a: &[T], b: &[T]) -> T {
     zip(a, b).fold(T::zero(), |acc, (x, y)| T::max(acc, T::abs(*x - *y)))
 }
@@ -252,6 +256,163 @@ fn test_solve_refined() {
     assert!(factors.solve_refined(&mut x, &b, 1e-13, 1e-12, 20, 5.0));
     let x_scaled: Vec<f64> = x_true.iter().map(|v| v / 1.1).collect();
     assert!(inf_norm_diff(&x_scaled, &x) <= 1e-10);
+}
+
+// A small quasidefinite KKT-like matrix [[diag(p) B'; B -diag(r)]] in
+// upper triangular CSC form, with the D signs it should factor with.
+#[cfg(test)]
+fn test_matrix_kkt_like(nx: usize, nz: usize, seed: u64) -> (CscMatrix<f64>, Vec<i8>) {
+    let mut state = seed;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f64) / ((1u64 << 31) as f64) - 1.0
+    };
+
+    let n = nx + nz;
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for j in 0..nx {
+        cols[j].push((j, 1.0 + next().abs()));
+    }
+    for j in 0..nz {
+        let col = nx + j;
+        for t in 0..3 {
+            let i = ((next().abs() * nx as f64) as usize + t * 7) % nx;
+            cols[col].push((i, next()));
+        }
+        cols[col].sort_by_key(|e| e.0);
+        cols[col].dedup_by_key(|e| e.0);
+        cols[col].push((col, -(1.0 + next().abs())));
+    }
+
+    let mut colptr = vec![0usize];
+    let (mut rowval, mut nzval) = (Vec::new(), Vec::new());
+    for c in &cols {
+        for &(i, v) in c {
+            rowval.push(i);
+            nzval.push(v);
+        }
+        colptr.push(rowval.len());
+    }
+    let mut signs = vec![1i8; n];
+    signs[nx..].fill(-1);
+    (
+        CscMatrix {
+            m: n,
+            n,
+            colptr,
+            rowval,
+            nzval,
+        },
+        signs,
+    )
+}
+
+// With exactly-representable values every product and sum below is
+// exact, so the both-triangles residual must agree with the triangular
+// symv *bitwise*.  Any disagreement would be a structural error in the
+// copy or its value map rather than a rounding difference.
+#[test]
+fn test_symmetric_copy_exact_on_integer_data() {
+    // upper triangular, small integers, some zero-free columns
+    //   [ 2  -1   0   3 ]
+    //   [    -4   5   0 ]
+    //   [         6  -2 ]
+    //   [             8 ]
+    let triu = CscMatrix {
+        m: 4,
+        n: 4,
+        colptr: vec![0, 1, 3, 5, 8],
+        rowval: vec![0, 0, 1, 1, 2, 0, 2, 3],
+        nzval: vec![2., -1., -4., 5., 6., 3., -2., 8.],
+    };
+
+    let mut sym = _build_symmetric_copy(&triu).unwrap();
+    for (dst, &k) in zip(&mut sym.A.nzval, &sym.sym_to_triu) {
+        *dst = triu.nzval[k as usize];
+    }
+    // 4 diagonal entries, 4 off-diagonal mirrored
+    assert_eq!(sym.A.nzval.len(), 2 * 8 - 4);
+
+    let x = [1., -2., 4., 8.];
+    let b = [100., -100., 50., 25.];
+
+    let mut e_ref = b;
+    triu.sym_up().symv(&mut e_ref, &x, -1.0, 1.0);
+
+    let mut e_new = [0.0; 4];
+    let norme = _sym_residual(&sym, &mut e_new, &b, &x);
+
+    assert_eq!(e_ref, e_new); // bitwise on exact data
+    assert_eq!(norme, inf_norm(&e_new));
+}
+
+// A non-finite solution must be reported rather than masked.  The running
+// maximum cannot see a NaN on its own, because IEEE maxNum returns the
+// non-NaN operand, so without explicit tracking a NaN residual would leave
+// the norm finite and the caller would accept a NaN solution as converged.
+#[test]
+fn test_sym_residual_reports_nan() {
+    let triu = CscMatrix {
+        m: 3,
+        n: 3,
+        colptr: vec![0, 1, 3, 6],
+        rowval: vec![0, 0, 1, 0, 1, 2],
+        nzval: vec![2.0, 1.0, 3.0, -1.0, 0.5, 4.0],
+    };
+    let mut sym = _build_symmetric_copy(&triu).unwrap();
+    for (dst, &k) in zip(&mut sym.A.nzval, &sym.sym_to_triu) {
+        *dst = triu.nzval[k as usize];
+    }
+    let b = [1.0, 2.0, 3.0];
+    let mut e = [0.0; 3];
+
+    // finite input: ordinary infinity norm
+    let n_ok: f64 = _sym_residual(&sym, &mut e, &b, &[1.0, 1.0, 1.0]);
+    assert!(n_ok.is_finite());
+
+    // one NaN in x taints its rows, and must be reported
+    let norme: f64 = _sym_residual(&sym, &mut e, &b, &[1.0, f64::NAN, 1.0]);
+    assert!(norme.is_nan(), "NaN residual must not be masked");
+}
+
+// The both-triangles copy must reproduce the matrix the triangular
+// symv represents, so that refinement residuals are unchanged in value
+// (they differ only in summation order).
+#[test]
+fn test_symmetric_copy_matches_triangular_symv() {
+    let (A, signs) = test_matrix_kkt_like(50, 35, 777);
+    let opts = QDLDLSettingsBuilder::<f64>::default()
+        .Dsigns(signs)
+        .build()
+        .unwrap();
+    let factors = QDLDLFactorisation::new(&A, Some(opts)).unwrap();
+
+    // the permuted internal matrix, and its both-triangles copy
+    let triu = &factors.workspace.triuA;
+    let mut sym = _build_symmetric_copy(triu).unwrap();
+    for (dst, &k) in zip(&mut sym.A.nzval, &sym.sym_to_triu) {
+        *dst = triu.nzval[k as usize];
+    }
+
+    let n = triu.ncols();
+    // every off-diagonal entry must appear on both sides
+    assert_eq!(sym.A.nzval.len(), 2 * triu.nzval.len() - n);
+
+    let x: Vec<f64> = (0..n).map(|i| ((i * 13) % 7) as f64 - 3.0).collect();
+    let b: Vec<f64> = (0..n).map(|i| ((i * 5) % 11) as f64 - 5.0).collect();
+
+    // reference: e = b - A*x via the triangular symv
+    let mut e_ref = b.clone();
+    triu.sym_up().symv(&mut e_ref, &x, -1.0, 1.0);
+
+    let mut e_new = vec![0.0; n];
+    let norme = _sym_residual(&sym, &mut e_new, &b, &x);
+
+    // same values up to summation order, and the returned norm agrees
+    assert!(inf_norm_diff(&e_ref, &e_new) <= 1e-10 * inf_norm(&e_ref).max(1.0));
+    assert!((norme - inf_norm(&e_new)).abs() <= 1e-12 * norme.max(1.0));
 }
 
 #[test]

--- a/src/qdldl/test.rs
+++ b/src/qdldl/test.rs
@@ -230,6 +230,31 @@ fn test_solve_basic() {
 }
 
 #[test]
+fn test_solve_refined() {
+    let A = test_matrix_4x4();
+    let mut factors = QDLDLFactorisation::new(&A, None).unwrap();
+    let x_true = [1., -2., 3., -4.];
+    let b = [20.0, -22.0, 32.0, -7.0];
+
+    // agrees with the plain solve
+    let mut x = [0.0; 4];
+    assert!(factors.solve_refined(&mut x, &b, 1e-13, 1e-12, 10, 5.0));
+    assert!(inf_norm_diff(&x_true, &x) <= 1e-10);
+
+    // refines against the values currently in the internal workspace,
+    // even where they differ from the factored ones: scale the matrix
+    // by 1.1 without refactoring, and refinement (contraction rate
+    // ||I - A⁻¹(1.1A)|| = 0.1 per pass) must converge to the solution
+    // of the *scaled* system using the stale factors
+    let indices: Vec<usize> = (0..A.nzval.len()).collect();
+    factors.scale_values(&indices, 1.1);
+    let mut x = [0.0; 4];
+    assert!(factors.solve_refined(&mut x, &b, 1e-13, 1e-12, 20, 5.0));
+    let x_scaled: Vec<f64> = x_true.iter().map(|v| v / 1.1).collect();
+    assert!(inf_norm_diff(&x_scaled, &x) <= 1e-10);
+}
+
+#[test]
 #[should_panic]
 fn test_solve_logical() {
     let A = test_matrix_4x4();

--- a/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/directldlkktsolver.rs
@@ -171,12 +171,28 @@ where
         lhsz: Option<&mut [T]>,
         settings: &CoreSettings<T>,
     ) -> bool {
-        self.ldlsolver.solve(&self.KKT, &mut self.x, &mut self.b);
-
         let is_success = {
             if settings.iterative_refinement_enable {
-                self.iterative_refinement(settings)
+                // backends may implement refinement internally (in their
+                // own permuted coordinates); otherwise refine here via
+                // repeated solves against our unpermuted KKT copy
+                let refined = self.ldlsolver.solve_refined(
+                    &mut self.x,
+                    &self.b,
+                    settings.iterative_refinement_reltol,
+                    settings.iterative_refinement_abstol,
+                    settings.iterative_refinement_max_iter,
+                    settings.iterative_refinement_stop_ratio,
+                );
+                match refined {
+                    Some(is_success) => is_success,
+                    None => {
+                        self.ldlsolver.solve(&self.KKT, &mut self.x, &mut self.b);
+                        self.iterative_refinement(settings)
+                    }
+                }
             } else {
+                self.ldlsolver.solve(&self.KKT, &mut self.x, &mut self.b);
                 self.x.is_finite()
             }
         };
@@ -253,11 +269,14 @@ where
         let is_success = self.ldlsolver.refactor(KKT);
 
         if settings.static_regularization_enable {
-            // put our internal copy of the KKT matrix back the way
-            // it was. Not necessary to fix the ldlsolver copy because
-            // this is only needed for our post-factorization IR scheme
+            // put our internal copy of the KKT matrix back the way it
+            // was, and likewise any internal copy held by the ldlsolver.
+            // Both are only used post-factorization, for computing
+            // iterative refinement residuals against the unregularized
+            // matrix; the shift is recomputed and reapplied from the
+            // restored diagonal before the next refactorization.
 
-            _update_values_KKT(KKT, &map.diag_full, diag_kkt);
+            _update_values(&mut self.ldlsolver, KKT, &map.diag_full, diag_kkt);
         }
 
         is_success

--- a/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/ldlsolvers/qdldl.rs
@@ -104,4 +104,23 @@ where
         self.factors.refactor().unwrap();
         self.factors.Dinv.is_finite()
     }
+
+    fn solve_refined(
+        &mut self,
+        x: &mut [T],
+        b: &[T],
+        reltol: T,
+        abstol: T,
+        max_iter: u32,
+        stop_ratio: T,
+    ) -> Option<bool> {
+        // QDLDL's internal matrix copy holds the values most recently
+        // written through update/scale/offset -- i.e. the unregularized
+        // diagonal, restored there after each refactorization -- so it can
+        // refine against the true KKT matrix in permuted coordinates.
+        Some(
+            self.factors
+                .solve_refined(x, b, reltol, abstol, max_iter, stop_ratio),
+        )
+    }
 }

--- a/src/solver/core/kktsolvers/direct/quasidef/mod.rs
+++ b/src/solver/core/kktsolvers/direct/quasidef/mod.rs
@@ -23,4 +23,24 @@ pub trait DirectLDLSolver<T: FloatT>: DirectLDLSolverReqs + HasLinearSolverInfo 
     fn offset_values(&mut self, index: &[usize], offset: T, signs: &[i8]);
     fn solve(&mut self, kkt: &CscMatrix<T>, x: &mut [T], b: &mut [T]);
     fn refactor(&mut self, kkt: &CscMatrix<T>) -> bool;
+
+    /// Solve with iterative refinement performed inside the backend,
+    /// against the backend's internal (unregularized) matrix copy.
+    /// Backends that maintain an internally permuted copy can run the
+    /// whole refinement loop in permuted coordinates, avoiding the
+    /// per-backsolve permutations of repeated `solve` calls.   Returns
+    /// None if the backend does not support this, in which case the
+    /// caller performs its own refinement via repeated `solve` calls.
+    #[allow(clippy::too_many_arguments)]
+    fn solve_refined(
+        &mut self,
+        _x: &mut [T],
+        _b: &[T],
+        _reltol: T,
+        _abstol: T,
+        _max_iter: u32,
+        _stop_ratio: T,
+    ) -> Option<bool> {
+        None
+    }
 }


### PR DESCRIPTION
Two commits, reviewable independently. Depends on nothing else; touches `src/qdldl/` and the direct-LDL KKT solver only.

## Motivation

After the factorization, the iterative-refinement residual `e = b − Ax` is the largest cost in the solve. Profiling stock Clarabel with `#[inline(never)]` on the candidate kernels, so inlined frames cannot be misattributed:

| | `mm_exdata` | `kennington_cre_b` |
|---|---|---|
| `_factor_inner` | 86.4% | 67.7% |
| **refinement residual (`_csc_symv_unsafe`)** | **7.5%** | **7.5%** |
| triangular solves | 2.9% | 15.1% |

The kernel is why: exploiting symmetry from the upper triangle alone requires **two scattered read-modify-writes per off-diagonal nonzero**, into `y[row]` and `y[col]` — the worst available memory pattern, and unvectorizable.

Separately, each refinement pass currently goes through `QDLDLFactorisation::solve`, which copies the right-hand side and applies the fill-reducing permutation and its inverse **per backsolve**.

## Commit 1 — run the refinement loop inside the backend

Adds `QDLDLFactorisation::solve_refined`: the same refinement algorithm — same residual definition, same stopping rules (tolerance, insufficient-improvement ratio with keep-if-improved, iteration cap), driven by the existing `iterative_refinement_*` settings — performed entirely in the internally permuted coordinates. The permutation is applied once to the right-hand side and once to the returned solution instead of once per backsolve.

A new `DirectLDLSolver::solve_refined` trait method defaults to "unsupported", so the faer and Pardiso backends keep the caller-side path untouched and only QDLDL takes the new one.

Supporting change: the static-regularization shift is restored in the backend's internal copy after each refactorization as well as in the caller's copy, so that copy holds the unregularized matrix between refactorizations, which is what refinement must target. Safe for all backends — the shift is recomputed from the restored diagonal before the next refactorization.

On its own this commit is performance-neutral on public problems (measured −0.0%); its value is putting the residual where commit 2 can replace it.

## Commit 2 — form the residual from a both-triangles copy

Keep a full both-triangles copy of the internally permuted matrix. Because it is symmetric, **its CSC arrays read as CSR describe the same matrix** — "column i" is exactly row i — so the residual becomes a sequence of independent sparse dot products: one streamed pass over values, gathered reads of `x`, an accumulator in a register, **no scatter**.

Four details, each with a reason:

- The copy is built on first use and refreshed only after the internal matrix changes, i.e. one O(nnz) pass per refactorization. The value map runs from each nonzero of the copy to its source, which makes that refresh a gather with sequential stores.
- Each row accumulates into **four** partial sums reduced pairwise. One accumulator serializes the row on the latency of a single dependent add; independent partial sums also carry a tighter error bound, growing like `n/k + k` for `k` accumulators rather than `n` (Higham, *Accuracy and Stability of Numerical Algorithms*, 2nd ed. 2002, §4.2, on blocked and pairwise summation). Measured: one accumulator is materially slower, eight is indistinguishable from four and needs more code.
- A **NaN residual is reported rather than masked**. A running maximum cannot detect one, because IEEE `maxNum` returns the non-NaN operand — which would leave the norm finite and let a non-finite search direction be accepted as converged. Not hypothetical: two MIPLIB relaxations in the gate below exercise it.
- It is an addition, not a replacement: if the pattern exceeds the `u32` value map, refinement falls back to the triangular product.

## Correctness

**Structural correctness is pinned exactly**, separating an error in the copy or its value map from mere rounding: `test_symmetric_copy_exact_on_integer_data` compares the new residual against the triangular product **bitwise** on exactly-representable integer data, where every product and sum is exact. `test_symmetric_copy_matches_triangular_symv` repeats it to tolerance on a pseudo-random quasidefinite matrix. `test_sym_residual_reports_nan` covers the NaN path, which no finite-data test can reach. `test_solve_refined` pins the refinement semantics: it asserts the loop refines against the values currently in the internal workspace rather than the ones that were factored, by rescaling the matrix without refactoring and requiring convergence to the rescaled system's solution.

Full suite green (`cargo test`, 20 binaries); `cargo clippy` clean.

On real data the residual differs from the previous formulation by rounding. Both are backward-stable evaluations of the same product, but a refinement residual is a difference of nearly equal quantities — as the solve converges, `b` and `Ax` cancel to many digits — so the two summation orders differ at roughly the level of that cancellation. On problems already at their double-precision conditioning floor this reshuffles the last few iterates, which is what the gates below bound.

For the record, a *more accurate* residual was tried and rejected: a compensated dot product (two-product via FMA plus two-sum, Ogita, Rump & Oishi, *SIAM J. Sci. Comput.* 26(6):1955–1988, 2005, Alg. 5.3), motivated by Higham ch. 12's requirement that refinement residuals be formed to higher precision. It was 16% slower — the compensation chain is serially dependent, so the loop becomes latency- rather than bandwidth-bound — and it did not stabilise termination statuses.

## Performance

Interleaved A/B — the binaries run alternately problem-by-problem within each round, so machine drift affects both equally — minimum over rounds, single-threaded release build. Problems are every small-, medium- and large-band problem of a locally converted public corpus, i.e. selected by size rather than by where the change was expected to help.

**67 small and medium problems** (Netlib 19, Netlib-Kennington 14, Maros–Mészáros 13, SDPLIB 19, structured conic 11, Mittelmann 2), 2 rounds × 2 reps:

| total | median | faster | flat | slower |
|---|---|---|---|---|
| 76.1s → 73.2s, **−3.8%** | **−5.7%** | 53 | 8 | 6 |

**13 large problems (>10s)**, 1 rep: 1451.1s → 1395.7s, **−3.8%**; 8 faster, 4 flat, 1 slower. Largest gains `sdplib_qap9` −20.3% (31 → 25 iterations), `sdplib_qap8` −11.3%, `sdplib_arch0` −9.5%, `kennington_osa_60` −9.0%.

A consistent but modest public gain: about 4% of total solve time, 6% at the median, on top of which refinement-dominated problems gain considerably more.

### The regressions, and why there is no gate for them

Seven of the 80 get slower: `conic_logreg_winewhite_exp` +25.0%, `sdplib_qap7` +4.8%, `sdplib_truss5` +4.6%, `sdplib_control5` +4.6%, `conic_pow3d_p25_winewhite_pow` +4.1%, `conic_logreg_winewhite2000_exp` +3.6%, `netlib_pilot` +2.7%.

These are almost all *iteration-count* changes rather than kernel slowdowns — `conic_logreg_winewhite_exp` 23 → 30 iterations, `sdplib_qap7` 26 → 29, `sdplib_control5` 34 → 38 — and the same mechanism produces the largest gain in the other direction, `sdplib_qap9` at 31 → 25. Perturbing the summation order of the residual moves marginal problems onto different iterate paths, and that cuts both ways. It cannot be predicted from a structural property of the matrix, so unlike the block-kernel decision in the companion factorization PR there is no gate to be had; the alternatives are this change as it stands, or not changing the residual.

## Regression gates

**224 public problems** (101 Maros–Mészáros QPs, 85 Netlib LPs, 24 structured conic, 12 Netlib-Kennington, 2 Mittelmann): 15 change iteration count; **one changes status** — `mm_qsierra`, Solved → AlmostSolved, with a **bit-identical objective**, finishing at dual residual 4.2e-8 against the 1e-8 tolerance and a duality gap of 1.5e-13, i.e. marginal by 4× on one criterion while returning the same answer to every printed digit. Three same-status objective differences exceed 1e-6 relative (`mm_qbeaconf` 1.2e-6, `netlib_forplan` 7.8e-6, `netlib_pilot_ja` 1.7e-6), all on problems terminating AlmostSolved in both versions.

Two further suites, fetched fresh and used only as gates:

**MIPLIB 2017 benchmark set as LP relaxations, 45 instances** (the MPS reader ignores INTORG/INTEND, so reading a MIPLIB file yields exactly the continuous relaxation), 90s limit: **1 status better** (`comp21_2idx` AlmostSolved → Solved), **0 worse**, **0 objective disagreements > 1e-6**.

**CBLIB, 84 instances** sampled across families, including `nb`, `nb_L1`, `nb_L2`, `nql30/60/180`, `qssp30/60`, `sched_*`: **2 status better** (`clay0304h`, `sched_100_50_orig`), **1 worse** (`sched_100_100_orig`, Solved → AlmostSolved, objective differing 1.1e-5), total time **−7.8%**. That regression is in an ill-conditioned family — CBLIB ships `_scaled` variants of exactly these problems because the originals are badly scaled, and on `sched_100_100_scaled` both versions report Solved and differ by 9.8e-6. All three CBLIB objective disagreements are in that family.

Conversion of the CBLIB instances was validated independently: `nb` solves to −5.0703094644e-2, matching its published DIMACS optimum (−0.05070309), and HiGHS agrees on the LP-only conversions (`gen_ip054`: 6765.209042728 versus 6765.2090428).

## Cost

Memory: the copy roughly doubles the stored matrix, plus a `u32` per nonzero of the copy for the value map.
